### PR TITLE
feat(jquery-ui): allow jquery-ui mouse interactions to be used on touch screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ You will need to send yourself the verification email and then link your social 
 ## Contact
 
 If you have any questions, please feel free to ask in the Discord server: https://discord.gg/U4JZfsu
+
+## Credits
+
+This minor extension uses the [furf/jquery-ui-touch-punch](https://github.com/furf/jquery-ui-touch-punch) library to enable touch on jQuery UI elements.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,3 @@ You will need to send yourself the verification email and then link your social 
 ## Contact
 
 If you have any questions, please feel free to ask in the Discord server: https://discord.gg/U4JZfsu
-
-## Credits
-
-The [furf/jquery-ui-touch-punch](https://github.com/furf/jquery-ui-touch-punch) library is used to enable touch on jQuery UI elements.

--- a/public/css/lorekeeper.css
+++ b/public/css/lorekeeper.css
@@ -68,6 +68,17 @@ body {
     height: auto !important;
 }
 
+.mobile-handle {
+    font-size: 1.75rem;
+    position: absolute;
+    top: -1rem;
+    right: 0;
+}
+
+.mobile-handle i {
+    transform: rotate(-25deg);
+}
+
 /**************************************************************************************************
 
     Layout

--- a/public/js/jquery.ui.touch-punch.min.js
+++ b/public/js/jquery.ui.touch-punch.min.js
@@ -1,0 +1,11 @@
+/*!
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);

--- a/resources/views/character/images.blade.php
+++ b/resources/views/character/images.blade.php
@@ -59,6 +59,11 @@
         {!! Form::hidden('sort', '', ['id' => 'sortableOrder']) !!}
         {!! Form::submit('Save Order', ['class' => 'btn btn-primary']) !!}
         {!! Form::close() !!}
+
+        <div class="mobile-handle handle-clone badge badge-primary rounded-circle hide">
+            <i class="fas fa-hand-point-up" aria-hidden="true"></i>
+            <span class="sr-only">Drag Handle</span>
+        </div>
     @endif
 @endsection
 @section('scripts')
@@ -82,6 +87,23 @@
                     }
                 });
                 $("#sortable").disableSelection();
+
+                function isTouch() {
+                    try {
+                        document.createEvent("TouchEvent"); return true;
+                    } catch(e) {
+                        return false;
+                    }
+                }
+
+                if (isTouch()) {
+                    $('#sortable').children().each(function() {
+                        var $clone = $('.handle-clone').clone();
+                        $(this).append($clone);
+                        $clone.removeClass('hide handle-clone');
+                    });
+                    $("#sortable").sortable("option", "handle", ".mobile-handle");
+                }
             });
         </script>
     @endif

--- a/resources/views/character/images.blade.php
+++ b/resources/views/character/images.blade.php
@@ -90,8 +90,9 @@
 
                 function isTouch() {
                     try {
-                        document.createEvent("TouchEvent"); return true;
-                    } catch(e) {
+                        document.createEvent("TouchEvent");
+                        return true;
+                    } catch (e) {
                         return false;
                     }
                 }

--- a/resources/views/home/characters.blade.php
+++ b/resources/views/home/characters.blade.php
@@ -56,8 +56,9 @@
 
             function isTouch() {
                 try {
-                    document.createEvent("TouchEvent"); return true;
-                } catch(e) {
+                    document.createEvent("TouchEvent");
+                    return true;
+                } catch (e) {
                     return false;
                 }
             }

--- a/resources/views/home/characters.blade.php
+++ b/resources/views/home/characters.blade.php
@@ -29,6 +29,11 @@
     {!! Form::hidden('sort', null, ['id' => 'sortableOrder']) !!}
     {!! Form::submit('Save Order', ['class' => 'btn btn-primary']) !!}
     {!! Form::close() !!}
+
+    <div class="mobile-handle handle-clone badge badge-primary rounded-circle hide">
+        <i class="fas fa-hand-point-up" aria-hidden="true"></i>
+        <span class="sr-only">Drag Handle</span>
+    </div>
 @endsection
 @section('scripts')
     <script>
@@ -48,6 +53,23 @@
                 }
             });
             $("#sortable").disableSelection();
+
+            function isTouch() {
+                try {
+                    document.createEvent("TouchEvent"); return true;
+                } catch(e) {
+                    return false;
+                }
+            }
+
+            if (isTouch()) {
+                $('#sortable').children().each(function() {
+                    var $clone = $('.handle-clone').clone();
+                    $(this).append($clone);
+                    $clone.removeClass('hide handle-clone');
+                });
+                $("#sortable").sortable("option", "handle", ".mobile-handle");
+            }
         });
     </script>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -52,6 +52,7 @@
     <script src="{{ asset('js/selectize.min.js') }}"></script>
     <script src="{{ asset('js/jquery-ui-timepicker-addon.js') }}"></script>
     <script src="{{ asset('js/croppie.min.js') }}"></script>
+    <script src="{{ asset('js/jquery.ui.touch-punch.min.js') }}"></script>
 
     <!-- Fonts -->
     <link rel="dns-prefetch" href="//fonts.gstatic.com">

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -76,7 +76,8 @@
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Submission_Drafts"><strong>Submission Drafts</strong></a> by <a href="https://github.com/preimpression/">Preimpression</a>
         </p>
         <p class="mb-0 col-md-4">
-            <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Touchscreen_Sortable"><strong>Touchscreen Sortable</strong></a> by <a href="https://github.com/liwoyadan">liwoyadan</a> (via <a href="https://github.com/furf/jquery-ui-touch-punch">Touch Punch</a>)
+            <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Touchscreen_Sortable"><strong>Touchscreen Sortable</strong></a> by <a href="https://github.com/liwoyadan">liwoyadan</a> (via <a
+                href="https://github.com/furf/jquery-ui-touch-punch">Touch Punch</a>)
         </p>
         <p class="mb-0 col-md-4">
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:User_Transfer_Reasons"><strong>User Transfer Reasons</strong></a> by <a href="https://github.com/snupsplus">Snupsplus</a>

--- a/resources/views/pages/credits.blade.php
+++ b/resources/views/pages/credits.blade.php
@@ -76,6 +76,9 @@
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Submission_Drafts"><strong>Submission Drafts</strong></a> by <a href="https://github.com/preimpression/">Preimpression</a>
         </p>
         <p class="mb-0 col-md-4">
+            <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:Touchscreen_Sortable"><strong>Touchscreen Sortable</strong></a> by <a href="https://github.com/liwoyadan">liwoyadan</a> (via <a href="https://github.com/furf/jquery-ui-touch-punch">Touch Punch</a>)
+        </p>
+        <p class="mb-0 col-md-4">
             <a href="http://wiki.lorekeeper.me/index.php?title=Extensions:User_Transfer_Reasons"><strong>User Transfer Reasons</strong></a> by <a href="https://github.com/snupsplus">Snupsplus</a>
         </p>
         <p class="mb-0 col-md-4">


### PR DESCRIPTION
Tossing this into dev upon suggestion in #1110. jQuery UI's interactable widgets (i.e. draggable, resizable, selectable, etc...but most prominently for Lorekeeper's use: sortable) relies on mouse events and thus won't register on touchscreen devices such as mobile phones or iPads. This addition includes the [furf/jquery-ui-touch-punch](https://github.com/furf/jquery-ui-touch-punch) library that, as long as it's included on the page where the widget is, will allow touchscreen touch events to interact with and manipulate the widget as well. It works automatically and you do not need to adjust any further code.

There's a write up on [the extension page I made](http://wiki.lorekeeper.me/index.php?title=Extensions:Touchscreen_Sortable) but both I and several others have tested this across multiple different Android, iPhone, iPad, and few other touchscreen devices and it works smoothly. The only remark I've seen of it not working is someone in a Stack Overflow comment from 2014 mentioning it wasn't working on mobile Internet Explorer on their Windows Phone, but given that it's 10 years from then now, IE Mobile lost support in 2023, and the Windows Phone's final release was in 2015...that's at least not likely to be an issue that will be run into nowadays.

Touch Punch is dual licensed under MIT and GPL Version 2 licenses and can be freely used, modified, and distributed but in the case of the last option it does need to be attributed. The author requests that the [Touch Punch website](http://touchpunch.furf.com/) be linked, but it seems that the website had gone down sometime in the last few months, so instead I've just linked directly to the repository as credit. You _can_ access the website through the Wayback Machine, though, and you can find a preview of it [here](https://web.archive.org/web/20160827114740/https://touchpunch.furf.com/) if you want to try testing the touch interactions on your own mobile device. (Though the site may not load everything very smoothly, given that it's just a capture of it from the past.)

One additional feature I have included in this is specifically on the `/characters` (My Characters) and `/character/{slug}/images` (Character Images) pages: there's just a little bit of additional JavaScript. It will attempt to create a touch event on the user's device to detect if it's a touchscreen or not. If it does detect a touchscreen, it will clone and append a round drag handle icon on each sortable element within the overall sortable and set it as the sortable's handle, making users touch and drag that icon specifically to reorder their characters/character images. The styling for this drag handle can be adjusted in `lorekeeper.css`. 

This feature is particularly for people on mobile phones - so they can touch and scroll the page without triggering the sortable function, given that on mobile viewports the sortable essentially takes up the entire width of the screen. These drag handles are also triggered if you are on browser developer tools with touch simulation enabled.

![A screenshot of the drag handle on the /characters page visible on touch devices.](http://wiki.lorekeeper.me/images/1/13/Characters_Sortable.png)

All you need to do is pull and merge; there are no additional commands necessary. For anyone reading this who wants this functionality on their own site but aren't on the dev branch, I will still have the v3 branch up and it is linked [on the extension page](http://wiki.lorekeeper.me/index.php?title=Extensions:Touchscreen_Sortable).