### PR TITLE
fix(ranks): parsed rank description upon initial setup

### DIFF
--- a/app/Console/Commands/SetupAdminUser.php
+++ b/app/Console/Commands/SetupAdminUser.php
@@ -48,11 +48,13 @@ class SetupAdminUser extends Command {
             $adminRank = Rank::create([
                 'name'        => 'Admin',
                 'description' => 'The site admin. Has the ability to view/edit any data on the site.',
+                'parsed_description' => 'The site admin. Has the ability to view/edit any data on the site.',
                 'sort'        => 1,
             ]);
             Rank::create([
                 'name'        => 'Member',
                 'description' => 'A regular member of the site.',
+                'parsed_description' => 'A regular member of the site.',
                 'sort'        => 0,
             ]);
 

--- a/app/Console/Commands/SetupAdminUser.php
+++ b/app/Console/Commands/SetupAdminUser.php
@@ -46,16 +46,16 @@ class SetupAdminUser extends Command {
         if (!Rank::count()) {
             // These need to be created even if the seeder isn't run for the site to work correctly.
             $adminRank = Rank::create([
-                'name'        => 'Admin',
-                'description' => 'The site admin. Has the ability to view/edit any data on the site.',
+                'name'               => 'Admin',
+                'description'        => 'The site admin. Has the ability to view/edit any data on the site.',
                 'parsed_description' => 'The site admin. Has the ability to view/edit any data on the site.',
-                'sort'        => 1,
+                'sort'               => 1,
             ]);
             Rank::create([
-                'name'        => 'Member',
-                'description' => 'A regular member of the site.',
+                'name'               => 'Member',
+                'description'        => 'A regular member of the site.',
                 'parsed_description' => 'A regular member of the site.',
-                'sort'        => 0,
+                'sort'               => 0,
             ]);
 
             $this->line('User ranks not found. Default user ranks (admin and basic member) created.');


### PR DESCRIPTION
The help tooltips next to a user's rank on their profile, upon initial setup, would not display a tooltip when hovered over. Looking at the profile content blade the help icon uses `parsed_description`, which is not set and left as null when running the `setup-admin-user` command while only the `description` column is filled. This just ensures that those tooltips actually show from the get-go, otherwise a site owner would have to go into ranks in the admin panel and hit edit on both Admin and Member ranks so the service's function fills `parsed_description` on update instead.