### PR TITLE
fix(gallery submissions): notifications to owners of included characters

### DIFF
--- a/app/Services/GalleryManager.php
+++ b/app/Services/GalleryManager.php
@@ -878,7 +878,7 @@ class GalleryManager extends Service {
                 // Send a notification to included characters' owners now that the submission is accepted
                 // but not for the submitting user's own characters
                 foreach ($submission->characters as $character) {
-                    if ($character->user && $character->character->user->id != $submission->user->id) {
+                    if ($character->character->user && $character->character->user->id != $submission->user->id) {
                         Notifications::create('GALLERY_SUBMISSION_CHARACTER', $character->character->user, [
                             'sender'        => $submission->user->name,
                             'sender_url'    => $submission->user->url,


### PR DESCRIPTION
Realized users (& myself) weren't really receiving notifications for owned characters being included in the gallery submissions of other users. Upon checking the code chunk for it I noticed the code checks for `$character->user` but the GalleryCharacter model does not have a user relation; this is a quick fix to make the check correctly go through `$character->character->user` instead like it does in other instances of that same code chunk.