### PR TITLE
style(limits): updating limits to bootstrap table

### DIFF
--- a/resources/views/widgets/_limits.blade.php
+++ b/resources/views/widgets/_limits.blade.php
@@ -18,31 +18,61 @@
         <p>
             You must obtain or complete all of the following in order to access this {{ $object->assetType ? (substr($object->assetType, -1) === 's' ? substr($object->assetType, 0, -1) : $object->assetType) : '' }}.
         </p>
-        <table class="table table-sm">
-            <thead>
-                <tr>
-                    <th width="30%">Limit Type</th>
-                    <th width="30%">Limit</th>
-                    <th width="20%">Quantity</th>
-                    <th width="20%">Is Debited?</th>
-                </tr>
-            </thead>
-            <tbody>
+        <div class="mb-2 logs-table">
+            <div class="logs-table-header">
+                <div class="row no-gutters">
+                    <div class="col-6 col-md-4">
+                        <div class="logs-table-cell">Limit Type</div>
+                    </div>
+                    <div class="col-6 col-md-4">
+                        <div class="logs-table-cell">Limit</div>
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <div class="logs-table-cell">Quantity</div>
+                    </div>
+                    <div class="col-6 col-md-2">
+                        <div class="logs-table-cell">Is Debited?</div>
+                    </div>
+                </div>
+            </div>
+            <div class="logs-table-body">
                 @foreach ($limits as $limit)
-                    <tr>
-                        <td data-toggle="tooltip" title="{{ config('lorekeeper.limits.limit_types')[$limit->limit_type]['description'] }}">
-                            <i class="fas fa-question-circle"></i>
-                            {{ $limitTypes[$limit->limit_type] }}
-                        </td>
-                        <td>{!! $limit->limit->displayName !!}</td>
-                        <td>{{ $limit->quantity > 0 ? $limit->quantity : 'N/A' }}</td>
-                        <td class="text-{{ $limit->debit ? 'success' : 'danger' }}">
-                            {{ $limit->debit ? 'Yes' : 'No' }}
-                        </td>
-                    </tr>
+                    <div class="logs-table-row">
+                        <div class="row no-gutters flex-wrap">
+                            <div class="col-6 col-md-4">
+                                <div class="logs-table-cell">
+                                    <i class="fas fa-question-circle mr-1" data-toggle="tooltip" title="{{ config('lorekeeper.limits.limit_types')[$limit->limit_type]['description'] }}"></i>
+                                    {{ $limitTypes[$limit->limit_type] }}
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-4">
+                                <div class="logs-table-cell">
+                                    {!! $limit->limit->displayName !!}
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="logs-table-cell">
+                                    {{ $limit->quantity > 0 ? 'x'.$limit->quantity : 'N/A' }}
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-2">
+                                <div class="logs-table-cell">
+                                    @if ($limit->debit)
+                                        <span class="badge badge-success" data-toggle="tooltip" title="This limit is debited from your account possessions.">
+                                            <i class="fas fa-check" aria-hidden="true"></i>
+                                        </span>
+                                    @else
+                                        <span class="badge badge-danger" data-toggle="tooltip" title="This limit will not be debited from your account.">
+                                            <i class="fas fa-times" aria-hidden="true"></i>
+                                        </span>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 @endforeach
-            </tbody>
-        </table>
+            </div>
+        </div>
         @if (!$hideUnlock)
             @if (Auth::check() && !$limits->first()->isUnlocked(Auth::user() ?? null) && !$limits->first()->is_auto_unlocked)
                 <div class="alert alert-secondary p-0 mt-2 mb-0">

--- a/resources/views/widgets/_limits.blade.php
+++ b/resources/views/widgets/_limits.blade.php
@@ -52,7 +52,7 @@
                             </div>
                             <div class="col-6 col-md-2">
                                 <div class="logs-table-cell">
-                                    {{ $limit->quantity > 0 ? 'x'.$limit->quantity : 'N/A' }}
+                                    {{ $limit->quantity > 0 ? 'x' . $limit->quantity : 'N/A' }}
                                 </div>
                             </div>
                             <div class="col-6 col-md-2">


### PR DESCRIPTION
Did this on the foraging extension and Newt mentioned it should be PR'd into develop since limits is part of develop now. o7 Just converts the table for the limits widget to be consistent like most other tables across the site: done with Bootstrap rows and columns rather than an actual table element.