### PR TITLE
fix(meta tags): no more extra spaces

### DIFF
--- a/resources/views/account/layout.blade.php
+++ b/resources/views/account/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Account ::
-    @yield('account-title')
+    Account{!! View::hasSection('account-title') ? ' :: ' . trim(View::getSection('account-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Admin ::
-    @yield('admin-title')
+    Admin{!! View::hasSection('admin-title') ? ' :: ' . trim(View::getSection('admin-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/character/design/layout.blade.php
+++ b/resources/views/character/design/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Design Approvals ::
-    @yield('design-title')
+    Design Approvals{!! View::hasSection('design-title') ? ' :: ' . trim(View::getSection('design-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/character/layout.blade.php
+++ b/resources/views/character/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Character ::
-    @yield('profile-title')
+    Character{!! View::hasSection('profile-title') ? ' :: ' . trim(View::getSection('profile-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/galleries/layout.blade.php
+++ b/resources/views/galleries/layout.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Gallery :: @yield('gallery-title')
+    Gallery{!! View::hasSection('gallery-title') ? ' :: ' . trim(View::getSection('gallery-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/home/layout.blade.php
+++ b/resources/views/home/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Home ::
-    @yield('home-title')
+    Home{!! View::hasSection('home-title') ? ' :: ' . trim(View::getSection('home-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,25 +16,25 @@
         {!! RecaptchaV3::initJs() !!}
     @endif
 
-    <title>{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} -@yield('title')</title>
+    <title>{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }}{!! View::hasSection('title') ? ' - ' . trim(View::getSection('title')) : '' !!}</title>
 
     <!-- Primary Meta Tags -->
-    <meta name="title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} -@yield('title')">
-    <meta name="description" content="@if (View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
+    <meta name="title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }}{!! View::hasSection('title') ? ' - ' . trim(View::getSection('title')) : '' !!}">
+    <meta name="description" content="{!! View::hasSection('meta-desc') ? trim(strip_tags(View::getSection('meta-desc'))) : config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') !!}">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ config('app.url', 'http://localhost') }}">
-    <meta property="og:image" content="@if (View::hasSection('meta-img')) @yield('meta-img') @else {{ asset('images/meta-image.png') }} @endif">
-    <meta property="og:title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} -@yield('title')">
-    <meta property="og:description" content="@if (View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
+    <meta property="og:image" content="{{ View::hasSection('meta-img') ? View::getSection('meta-img') : asset('images/meta-image.png') }}">
+    <meta property="og:title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }}{!! View::hasSection('title') ? ' - ' . trim(View::getSection('title')) : '' !!}">
+    <meta property="og:description" content="{!! View::hasSection('meta-desc') ? trim(strip_tags(View::getSection('meta-desc'))) : config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') !!}">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="{{ config('app.url', 'http://localhost') }}">
-    <meta property="twitter:image" content="@if (View::hasSection('meta-img')) @yield('meta-img') @else {{ asset('images/meta-image.png') }} @endif">
-    <meta property="twitter:title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }} -@yield('title')">
-    <meta property="twitter:description" content="@if (View::hasSection('meta-desc')) @yield('meta-desc') @else {{ config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') }} @endif">
+    <meta property="twitter:image" content="{{ View::hasSection('meta-img') ? View::getSection('meta-img') : asset('images/meta-image.png') }}">
+    <meta property="twitter:title" content="{{ config('lorekeeper.settings.site_name', 'Lorekeeper') }}{!! View::hasSection('title') ? ' - ' . trim(View::getSection('title')) : '' !!}">
+    <meta property="twitter:description" content="{!! View::hasSection('meta-desc') ? trim(strip_tags(View::getSection('meta-desc'))) : config('lorekeeper.settings.site_desc', 'A Lorekeeper ARPG') !!}">
 
     <!-- No AI scraping directives -->
     <meta name="robots" content="noai">

--- a/resources/views/news/layout.blade.php
+++ b/resources/views/news/layout.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Site News :: @yield('news-title')
+    Site News{!! View::hasSection('news-title') ? ' :: ' . trim(View::getSection('news-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/prompts/layout.blade.php
+++ b/resources/views/prompts/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Prompts ::
-    @yield('prompts-title')
+    Prompts{!! View::hasSection('prompts-title') ? ' :: ' . trim(View::getSection('prompts-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/sales/layout.blade.php
+++ b/resources/views/sales/layout.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Site Sales :: @yield('sales-title')
+    Site Sales{!! View::hasSection('sales-title') ? ' :: ' . trim(View::getSection('sales-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/shops/layout.blade.php
+++ b/resources/views/shops/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    Shops ::
-    @yield('shops-title')
+    Shops{!! View::hasSection('shops-title') ? ' :: ' . trim(View::getSection('shops-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/user/layout.blade.php
+++ b/resources/views/user/layout.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    User ::@yield('profile-title')
+    User{!! View::hasSection('profile-title') ? ' :: ' . trim(View::getSection('profile-title')) : '' !!}
 @endsection
 
 @section('sidebar')

--- a/resources/views/world/item_page.blade.php
+++ b/resources/views/world/item_page.blade.php
@@ -9,16 +9,7 @@
 @endsection
 
 @section('meta-desc')
-    @if (isset($item->category) && $item->category)
-        <p><strong>Category:</strong> {{ $item->category->name }}</p>
-    @endif
-    @if (isset($item->rarity) && $item->rarity)
-        :: <p><strong>Rarity:</strong> {{ $item->rarity }}: {{ $item->rarityName }}</p>
-    @endif
-    :: {!! substr(str_replace('"', '&#39;', $item->description), 0, 69) !!}
-    @if (isset($item->uses) && $item->uses)
-        :: <p><strong>Uses:</strong> {!! $item->uses !!}</p>
-    @endif
+    {!! isset($item->category) && $item->category ? '(Category: ' . $item->category->name . ')' : '' !!} {!! isset($item->rarity) && $item->rarity ? '(Rarity: ' . $item->rarity . ')' : '' !!} {!! substr(strip_tags($item->description), 0, 200) !!} {!! isset($item->uses) && $item->uses ? '(Uses: ' . $item->uses . ')' : '' !!}
 @endsection
 
 @section('content')

--- a/resources/views/world/layout.blade.php
+++ b/resources/views/world/layout.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts.app')
 
 @section('title')
-    World ::
-    @yield('world-title')
+    World{!! View::hasSection('world-title') ? ' :: ' . trim(View::getSection('world-title')) : '' !!}
 @endsection
 
 @section('sidebar')


### PR DESCRIPTION
Since the new blade formatting there has been extra space rendered in meta tag titles when yielded. This trims off the extra space and also only renders the trailing `-` after the site's title (as well as the `::`) if there is an additional title yielded. Below are just preview screenshots displaying the before and after for Discord embeds when linking a user's characters page.
<img width="348" height="303" alt="Previously generated Discord embed" src="https://github.com/user-attachments/assets/e10e5694-35f8-4443-adf5-0ee00491b1a3" />
<img width="330" height="306" alt="Discord embed generation now" src="https://github.com/user-attachments/assets/e55922d9-1b67-4920-b112-295494dc8cab" />

Meta descriptions have tags stripped because...I don't think those actually render? (thinking emoji) Previewing the opengraph/facebook/twitter/etc embeds the tags show up along with the text as `<p><strong>` so I figured it could just be taken out.