### PR TITLE
refactor: remove redundant meta-img sections in character blades

### DIFF
--- a/resources/views/character/bank.blade.php
+++ b/resources/views/character/bank.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Bank
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     {!! breadcrumbs([
         $character->category->masterlist_sub_id ? $character->category->sublist->name . ' Masterlist' : 'Character masterlist' => $character->category->masterlist_sub_id ? 'sublist/' . $character->category->sublist->key : 'masterlist',

--- a/resources/views/character/character.blade.php
+++ b/resources/views/character/character.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url]) !!}

--- a/resources/views/character/character_logs.blade.php
+++ b/resources/views/character/character_logs.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Change Log
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url, 'Change Log' => $character->url . '/change-log']) !!}

--- a/resources/views/character/currency_logs.blade.php
+++ b/resources/views/character/currency_logs.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Currency Logs
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     {!! breadcrumbs([
         $character->category->masterlist_sub_id ? $character->category->sublist->name . ' Masterlist' : 'Character masterlist' => $character->category->masterlist_sub_id ? 'sublist/' . $character->category->sublist->key : 'masterlist',

--- a/resources/views/character/edit_profile.blade.php
+++ b/resources/views/character/edit_profile.blade.php
@@ -4,10 +4,6 @@
     Editing {{ $character->fullName }}'s Profile
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url, 'Editing Profile' => $character->url . '/profile/edit']) !!}

--- a/resources/views/character/gallery.blade.php
+++ b/resources/views/character/gallery.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Gallery
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url, 'Gallery' => $character->url . '/gallery']) !!}

--- a/resources/views/character/images.blade.php
+++ b/resources/views/character/images.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Images
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     {!! breadcrumbs([
         $character->category->masterlist_sub_id ? $character->category->sublist->name . ' Masterlist' : 'Character masterlist' => $character->category->masterlist_sub_id ? 'sublist/' . $character->category->sublist->key : 'masterlist',

--- a/resources/views/character/layout.blade.php
+++ b/resources/views/character/layout.blade.php
@@ -4,6 +4,10 @@
     Character{!! View::hasSection('profile-title') ? ' :: ' . trim(View::getSection('profile-title')) : '' !!}
 @endsection
 
+@section('meta-img')
+    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
+@endsection
+
 @section('sidebar')
     @include('character.' . ($isMyo ? 'myo.' : '') . '_sidebar')
 @endsection

--- a/resources/views/character/ownership_logs.blade.php
+++ b/resources/views/character/ownership_logs.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Ownership History
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url, 'Ownership History' => $character->url . '/ownership']) !!}

--- a/resources/views/character/profile.blade.php
+++ b/resources/views/character/profile.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Profile
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url, 'Profile' => $character->url . '/profile']) !!}

--- a/resources/views/character/submission_logs.blade.php
+++ b/resources/views/character/submission_logs.blade.php
@@ -4,10 +4,6 @@
     {{ $character->fullName }}'s Submissions
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     {!! breadcrumbs([
         $character->category->masterlist_sub_id ? $character->category->sublist->name . ' Masterlist' : 'Character masterlist' => $character->category->masterlist_sub_id ? 'sublist/' . $character->category->sublist->key : 'masterlist',

--- a/resources/views/character/transfer.blade.php
+++ b/resources/views/character/transfer.blade.php
@@ -4,10 +4,6 @@
     Transferring {{ $character->fullName }}
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url, 'Transfer' => $character->url . '/transfer']) !!}

--- a/resources/views/character/update_form.blade.php
+++ b/resources/views/character/update_form.blade.php
@@ -4,10 +4,6 @@
     {{ $character->is_myo_slot ? 'MYO Approval' : 'Design Update' }} for {{ $character->fullName }}
 @endsection
 
-@section('meta-img')
-    {{ $character->image->content_warnings ? asset('images/content-warning.png') : $character->image->thumbnailUrl }}
-@endsection
-
 @section('profile-content')
     @if ($character->is_myo_slot)
         {!! breadcrumbs(['MYO Slot Masterlist' => 'myos', $character->fullName => $character->url, $character->is_myo_slot ? 'MYO Approval' : 'Design Update' => $character->url . '/approval']) !!}


### PR DESCRIPTION
Doesn't need to be multiple `meta-img` sections across character blades, just sticking it in the `character/layout.blade.php` is fine since all those other character pages extend it anyways. A refactor just to make things less redundant. :saluting_face: 