### PR TITLE
fix(character warnings): wrapping in auth to prevent permission error

### DIFF
--- a/resources/views/widgets/_character_warning_js.blade.php
+++ b/resources/views/widgets/_character_warning_js.blade.php
@@ -1,44 +1,44 @@
     @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
-    <script>
-        $(document).ready(function() {
-            $.ajax({
-                url: "{{ url('admin/masterlist/get-warnings') }}",
-                type: "GET",
-                dataType: 'json',
+        <script>
+            $(document).ready(function() {
+                $.ajax({
+                    url: "{{ url('admin/masterlist/get-warnings') }}",
+                    type: "GET",
+                    dataType: 'json',
 
-                error: function(data) {
-                    console.log('Error getting warnings');
-                    console.log(data);
-                },
-                success: function(options) {
-                    $('#warningList').selectize({
-                        plugins: ["restore_on_backspace", "remove_button"],
-                        delimiter: ",",
-                        valueField: 'warning',
-                        labelField: 'warning',
-                        searchField: 'warning',
-                        persist: false,
-                        create: true,
-                        preload: true,
-                        options: options,
-                        onInitialize: function() {
-                            let existingOptions = this.$input.attr('data-init-value') ? JSON.parse(this.$input.attr('data-init-value')) : [];
-                            var self = this;
-                            if (Object.prototype.toString.call(existingOptions) ===
-                                "[object Array]") {
-                                existingOptions.forEach(function(existingOption) {
-                                    self.addOption(existingOption);
-                                    self.addItem(existingOption[self.settings
-                                        .valueField]);
-                                });
-                            } else if (typeof existingOptions === 'object') {
-                                self.addOption(existingOptions);
-                                self.addItem(existingOptions[self.settings.valueField]);
+                    error: function(data) {
+                        console.log('Error getting warnings');
+                        console.log(data);
+                    },
+                    success: function(options) {
+                        $('#warningList').selectize({
+                            plugins: ["restore_on_backspace", "remove_button"],
+                            delimiter: ",",
+                            valueField: 'warning',
+                            labelField: 'warning',
+                            searchField: 'warning',
+                            persist: false,
+                            create: true,
+                            preload: true,
+                            options: options,
+                            onInitialize: function() {
+                                let existingOptions = this.$input.attr('data-init-value') ? JSON.parse(this.$input.attr('data-init-value')) : [];
+                                var self = this;
+                                if (Object.prototype.toString.call(existingOptions) ===
+                                    "[object Array]") {
+                                    existingOptions.forEach(function(existingOption) {
+                                        self.addOption(existingOption);
+                                        self.addItem(existingOption[self.settings
+                                            .valueField]);
+                                    });
+                                } else if (typeof existingOptions === 'object') {
+                                    self.addOption(existingOptions);
+                                    self.addItem(existingOptions[self.settings.valueField]);
+                                }
                             }
-                        }
-                    });
-                },
+                        });
+                    },
+                });
             });
-        });
-    </script>
-@endif
+        </script>
+    @endif

--- a/resources/views/widgets/_character_warning_js.blade.php
+++ b/resources/views/widgets/_character_warning_js.blade.php
@@ -1,42 +1,44 @@
-<script>
-    $(document).ready(function() {
-        $.ajax({
-            url: "{{ url('admin/masterlist/get-warnings') }}",
-            type: "GET",
-            dataType: 'json',
+    @if (Auth::check() && Auth::user()->hasPower('manage_characters'))
+    <script>
+        $(document).ready(function() {
+            $.ajax({
+                url: "{{ url('admin/masterlist/get-warnings') }}",
+                type: "GET",
+                dataType: 'json',
 
-            error: function(data) {
-                console.log('Error getting warnings');
-                console.log(data);
-            },
-            success: function(options) {
-                $('#warningList').selectize({
-                    plugins: ["restore_on_backspace", "remove_button"],
-                    delimiter: ",",
-                    valueField: 'warning',
-                    labelField: 'warning',
-                    searchField: 'warning',
-                    persist: false,
-                    create: true,
-                    preload: true,
-                    options: options,
-                    onInitialize: function() {
-                        let existingOptions = this.$input.attr('data-init-value') ? JSON.parse(this.$input.attr('data-init-value')) : [];
-                        var self = this;
-                        if (Object.prototype.toString.call(existingOptions) ===
-                            "[object Array]") {
-                            existingOptions.forEach(function(existingOption) {
-                                self.addOption(existingOption);
-                                self.addItem(existingOption[self.settings
-                                    .valueField]);
-                            });
-                        } else if (typeof existingOptions === 'object') {
-                            self.addOption(existingOptions);
-                            self.addItem(existingOptions[self.settings.valueField]);
+                error: function(data) {
+                    console.log('Error getting warnings');
+                    console.log(data);
+                },
+                success: function(options) {
+                    $('#warningList').selectize({
+                        plugins: ["restore_on_backspace", "remove_button"],
+                        delimiter: ",",
+                        valueField: 'warning',
+                        labelField: 'warning',
+                        searchField: 'warning',
+                        persist: false,
+                        create: true,
+                        preload: true,
+                        options: options,
+                        onInitialize: function() {
+                            let existingOptions = this.$input.attr('data-init-value') ? JSON.parse(this.$input.attr('data-init-value')) : [];
+                            var self = this;
+                            if (Object.prototype.toString.call(existingOptions) ===
+                                "[object Array]") {
+                                existingOptions.forEach(function(existingOption) {
+                                    self.addOption(existingOption);
+                                    self.addItem(existingOption[self.settings
+                                        .valueField]);
+                                });
+                            } else if (typeof existingOptions === 'object') {
+                                self.addOption(existingOptions);
+                                self.addItem(existingOptions[self.settings.valueField]);
+                            }
                         }
-                    }
-                });
-            },
+                    });
+                },
+            });
         });
-    });
-</script>
+    </script>
+@endif


### PR DESCRIPTION
So it does seem this was the issue the whole time...for context: I had begun to investigate the persistent `You do not have the permission to access this page.` error that had been occurring across multiple sites despite users seemingly not have done anything to warrant the error to occur. What I did was set up logging in the `CheckStaff`, `CheckPower`, and `CheckAdmin` middleware using the following:

> `Log::channel('permission_error')->warning('Permission denied (CheckStaff) ', ['user' => ($request->user()->name ?? 'Unknown'), 'route_action' => var_dump(Route::current()->action), 'route_uri' => Route::current()->uri, 'path' => $request->fullUrl()]);`

With the `(CheckStaff)` in parenthesis replaced by which file it was in. Immediately, in a single 24 hour period, it had logged _over a thousand_ entries (granted, site has a relatively large userbase) and every single one of those entries was solely from `CheckStaff`. It was this:

> `production.WARNING: Permission denied (CheckStaff) {"user":"(someone's username)","route_action":null,"route_uri":"admin/masterlist/get-warnings","path":"https://www.site-name.com/admin/masterlist/get-warnings"}`

That route is included in every image info blade at the bottom. Likewise, if you currently visit a site on the develop branch, open console in devtools, and visit a character's page, you will see a `Error getting warnings`. So I wrapped the script in an Auth check + hasPower for staff users who would have permission to access that route in the first place, and immediately the following day after the 1000+ entries, only 14 entries were logged for this error. The day after that only 12. The day after that only 4. Since the 14th, not a single entry for a permission denied being hit has been logged nor any users stating they continue to experience it; I think moif was right about perhaps the stragglers having been a cache issue - reviewing the logs did show that the users in those following 3 days after wrapping the script in the check had all been the same users repeatedly before no longer appearing in the logs.

Check is just in the widget itself for convenience so if someone decides to re-use it elsewhere it's already wrapped in the check...but this seems to have been the mystery behind the persistent `You do not have the permission to access this page.` issue across many sites.