### PR TITLE
fix(items): stack_name missing from character's item pivot

### DIFF
--- a/app/Models/Character/Character.php
+++ b/app/Models/Character/Character.php
@@ -190,7 +190,7 @@ class Character extends Model {
      * Get the character's items.
      */
     public function items() {
-        return $this->belongsToMany(Item::class, 'character_items')->withPivot('count', 'data', 'updated_at', 'id')->whereNull('character_items.deleted_at');
+        return $this->belongsToMany(Item::class, 'character_items')->withPivot('count', 'data', 'updated_at', 'id', 'stack_name')->whereNull('character_items.deleted_at');
     }
 
     /**********************************************************************************************


### PR DESCRIPTION
Names of named items in character inventories were not showing up as `stack_name` was not included within the `withPivot`...just a tiny fix so it's actually included in the pivot now.