### PR TITLE
refactor: change Limit, Reward, and Loot into polymorphic traits

### DIFF
--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -152,15 +152,15 @@ function getAssetModelString($type, $namespaced = true) {
                 return 'Prompt';
             }
             break;
-            
-        case 'dynamic': 
+
+        case 'dynamic':
             if ($namespaced) {
                 return '\App\Models\Limit\DynamicLimit';
             } else {
                 return 'DynamicLimit';
             }
             break;
-        
+
         case 'itemcategory': case 'itemcategoryrarity':
             if ($namespaced) {
                 return '\App\Models\Item\ItemCategory';

--- a/app/Helpers/AssetHelpers.php
+++ b/app/Helpers/AssetHelpers.php
@@ -152,6 +152,22 @@ function getAssetModelString($type, $namespaced = true) {
                 return 'Prompt';
             }
             break;
+            
+        case 'dynamic': 
+            if ($namespaced) {
+                return '\App\Models\Limit\DynamicLimit';
+            } else {
+                return 'DynamicLimit';
+            }
+            break;
+        
+        case 'itemcategory': case 'itemcategoryrarity':
+            if ($namespaced) {
+                return '\App\Models\Item\ItemCategory';
+            } else {
+                return 'ItemCategory';
+            }
+            break;
     }
 
     return null;

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -481,7 +481,7 @@ function faVersion() {
  * @return bool
  */
 function getLimits($object) {
-    if(in_array(\App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
+    if (in_array(App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
         return $object->hasLimits;
     } else {
         return null;
@@ -494,7 +494,7 @@ function getLimits($object) {
  * @param mixed $object
  */
 function hasLimits($object) {
-    if(in_array(\App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
+    if (in_array(App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
         return $object->hasLimits;
     } else {
         return null;
@@ -516,7 +516,7 @@ function hasUnlockedLimits($user, $object) {
         ->where('object_model', get_class($object))
         ->where('object_id', $object->id)
         ->count();
-    }
+}
 
 /**
  * Returns the given objects rewards, if any.
@@ -526,7 +526,7 @@ function hasUnlockedLimits($user, $object) {
  * @return bool
  */
 function getRewards($object) {
-    if(in_array(\App\Traits\Rewardable::class, class_uses_recursive(get_class($object)))) {
+    if (in_array(App\Traits\Rewardable::class, class_uses_recursive(get_class($object)))) {
         return $object->rewards;
     } else {
         return null;
@@ -539,7 +539,7 @@ function getRewards($object) {
  * @param mixed $object
  */
 function hasRewards($object) {
-    if(in_array(\App\Traits\Rewardable::class, class_uses_recursive(get_class($object)))) {
+    if (in_array(App\Traits\Rewardable::class, class_uses_recursive(get_class($object)))) {
         return $object->hasRewards;
     } else {
         return null;

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -481,7 +481,7 @@ function faVersion() {
  * @return mixed
  */
 function getLimits($object) {
-    if(in_array(\App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
+    if (in_array(App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
         return $object->limits;
     } else {
         return null;
@@ -492,7 +492,7 @@ function getLimits($object) {
  * checks if a certain object has any limits.
  *
  * @param mixed $object
- * 
+ *
  * @return bool
  */
 function hasLimits($object) {

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -481,7 +481,11 @@ function faVersion() {
  * @return bool
  */
 function getLimits($object) {
-    return App\Models\Limit\Limit::where('object_model', get_class($object))->where('object_id', $object->id)->get();
+    if(in_array(\App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
+        return $object->hasLimits;
+    } else {
+        return null;
+    }
 }
 
 /**
@@ -490,7 +494,11 @@ function getLimits($object) {
  * @param mixed $object
  */
 function hasLimits($object) {
-    return App\Models\Limit\Limit::where('object_model', get_class($object))->where('object_id', $object->id)->exists();
+    if(in_array(\App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
+        return $object->hasLimits;
+    } else {
+        return null;
+    }
 }
 
 /**
@@ -504,11 +512,11 @@ function hasUnlockedLimits($user, $object) {
         return true;
     }
 
-    return App\Models\Limit\UserUnlockedLimit::where('user_id', $user->id)
+    return $user->unlockedLimits
         ->where('object_model', get_class($object))
         ->where('object_id', $object->id)
-        ->exists();
-}
+        ->count();
+    }
 
 /**
  * Returns the given objects rewards, if any.
@@ -518,7 +526,11 @@ function hasUnlockedLimits($user, $object) {
  * @return bool
  */
 function getRewards($object) {
-    return App\Models\Reward\Reward::where('object_model', get_class($object))->where('object_id', $object->id)->get();
+    if(in_array(\App\Traits\Rewardable::class, class_uses_recursive(get_class($object)))) {
+        return $object->rewards;
+    } else {
+        return null;
+    }
 }
 
 /**
@@ -527,5 +539,9 @@ function getRewards($object) {
  * @param mixed $object
  */
 function hasRewards($object) {
-    return App\Models\Reward\Reward::where('object_model', get_class($object))->where('object_id', $object->id)->exists();
+    if(in_array(\App\Traits\Rewardable::class, class_uses_recursive(get_class($object)))) {
+        return $object->hasRewards;
+    } else {
+        return null;
+    }
 }

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -478,11 +478,11 @@ function faVersion() {
  *
  * @param mixed $object
  *
- * @return bool
+ * @return mixed
  */
 function getLimits($object) {
     if(in_array(\App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
-        return $object->hasLimits;
+        return $object->limits;
     } else {
         return null;
     }
@@ -492,12 +492,14 @@ function getLimits($object) {
  * checks if a certain object has any limits.
  *
  * @param mixed $object
+ * 
+ * @return bool
  */
 function hasLimits($object) {
     if(in_array(\App\Traits\Limitable::class, class_uses_recursive(get_class($object)))) {
         return $object->hasLimits;
     } else {
-        return null;
+        return false;
     }
 }
 
@@ -542,6 +544,6 @@ function hasRewards($object) {
     if(in_array(\App\Traits\Rewardable::class, class_uses_recursive(get_class($object)))) {
         return $object->hasRewards;
     } else {
-        return null;
+        return false;
     }
 }

--- a/app/Http/Controllers/PromptsController.php
+++ b/app/Http/Controllers/PromptsController.php
@@ -50,7 +50,7 @@ class PromptsController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getPrompts(Request $request) {
-        $query = Prompt::active()->staffOnly(Auth::user() ?? null)->with('category');
+        $query = Prompt::active()->staffOnly(Auth::user() ?? null)->with('category', 'limits', 'rewards');
         $data = $request->only(['prompt_category_id', 'name', 'sort', 'open_prompts']);
         if (isset($data['prompt_category_id']) && $data['prompt_category_id'] != 'none') {
             if ($data['prompt_category_id'] == 'withoutOption') {
@@ -126,7 +126,7 @@ class PromptsController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getPrompt(Request $request, $id) {
-        $prompt = Prompt::active()->where('id', $id)->first();
+        $prompt = Prompt::active()->where('id', $id)->with('limits', 'rewards')->first();
 
         if (!$prompt) {
             abort(404);

--- a/app/Models/Limit/Limit.php
+++ b/app/Models/Limit/Limit.php
@@ -2,11 +2,7 @@
 
 namespace App\Models\Limit;
 
-use App\Models\Currency\Currency;
-use App\Models\Item\Item;
 use App\Models\Model;
-use App\Models\Prompt\Prompt;
-use Illuminate\Database\Eloquent\Relations\Relation;
 
 class Limit extends Model {
     /**
@@ -60,12 +56,12 @@ class Limit extends Model {
     public function limit() {
         return $this->morphTo('limit', 'limit_type', 'limit_id');
 
-        /* 
+        /*
          * If you have specific logic per limit_type (such as, if you have multiple limits that share the same model),
          * you can use ->constrain([]) to handle that extra logic.
-         * 
+         *
          * For example, if you were to have a generic "Model" that needs to be separated between character and user:
-         * 
+         *
          * ->constrain([
          *     Model::class => function ($query) {
          *         if ($this->limit_type === 'user_model') {
@@ -75,7 +71,7 @@ class Limit extends Model {
          *         }
          *     }
          * ]);
-         * 
+         *
          */
     }
 

--- a/app/Models/Limit/Limit.php
+++ b/app/Models/Limit/Limit.php
@@ -6,6 +6,7 @@ use App\Models\Currency\Currency;
 use App\Models\Item\Item;
 use App\Models\Model;
 use App\Models\Prompt\Prompt;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class Limit extends Model {
     /**
@@ -24,6 +25,15 @@ class Limit extends Model {
      */
     protected $table = 'limits';
 
+    /**
+     * The relationships that should always be loaded.
+     *
+     * @var array
+     */
+    protected $with = [
+        'limit',
+    ];
+
     /**********************************************************************************************
 
         RELATIONS
@@ -31,26 +41,42 @@ class Limit extends Model {
     **********************************************************************************************/
 
     /**
-     * get the object of this type.
+     * Get the object that this limit is attached to as something that morphMany will accept.
+     */
+    public function limitable() {
+        return $this->morphTo('limitable', 'object_model', 'object_id');
+    }
+
+    /**
+     * Get the object that this limit is attached to.
      */
     public function object() {
-        return $this->belongsTo($this->object_model, 'object_id');
+        return $this->morphTo('object', 'object_model', 'object_id');
     }
 
     /**
      * gets the limit of this ... limit.
      */
     public function limit() {
-        switch ($this->limit_type) {
-            case 'prompt':
-                return $this->belongsTo(Prompt::class, 'limit_id');
-            case 'item':
-                return $this->belongsTo(Item::class, 'limit_id');
-            case 'currency':
-                return $this->belongsTo(Currency::class, 'limit_id');
-            case 'dynamic':
-                return $this->belongsTo(DynamicLimit::class, 'limit_id');
-        }
+        return $this->morphTo('limit', 'limit_type', 'limit_id');
+
+        /* 
+         * If you have specific logic per limit_type (such as, if you have multiple limits that share the same model),
+         * you can use ->constrain([]) to handle that extra logic.
+         * 
+         * For example, if you were to have a generic "Model" that needs to be separated between character and user:
+         * 
+         * ->constrain([
+         *     Model::class => function ($query) {
+         *         if ($this->limit_type === 'user_model') {
+         *             $query->where('type', 'user');
+         *         } elseif ($this->limit_type === 'character_model') {
+         *             $query->where('type', 'character');
+         *         }
+         *     }
+         * ]);
+         * 
+         */
     }
 
     /**********************************************************************************************
@@ -60,21 +86,23 @@ class Limit extends Model {
     **********************************************************************************************/
 
     /**
-     * checks if a certain object has any limits.
+     * Checks if a certain object has any limits.
+     * This is kept for backwards compatibility, and forwards to the helper function.
      *
      * @param mixed $object
      */
     public static function hasLimits($object) {
-        return self::where('object_model', get_class($object))->where('object_id', $object->id)->exists();
+        return hasLimits($object);
     }
 
     /**
-     * get the limits of a certain object.
+     * Get the limits of a certain object.
+     * This is kept for backwards compatibility, and forwards to the helper function.
      *
      * @param mixed $object
      */
     public static function getLimits($object) {
-        return self::where('object_model', get_class($object))->where('object_id', $object->id)->get();
+        return getLimits($object);
     }
 
     /**
@@ -87,6 +115,6 @@ class Limit extends Model {
             return false;
         }
 
-        return $this->is_unlocked && $user->unlockedLimits()->where('object_model', $this->object_model)->where('object_id', $this->object_id)->exists();
+        return $this->is_unlocked && $user->unlockedLimits->where('object_model', $this->object_model)->where('object_id', $this->object_id)->count();
     }
 }

--- a/app/Models/Loot/Loot.php
+++ b/app/Models/Loot/Loot.php
@@ -2,9 +2,6 @@
 
 namespace App\Models\Loot;
 
-use App\Models\Currency\Currency;
-use App\Models\Item\Item;
-use App\Models\Item\ItemCategory;
 use App\Models\Model;
 
 class Loot extends Model {

--- a/app/Models/Loot/Loot.php
+++ b/app/Models/Loot/Loot.php
@@ -68,24 +68,7 @@ class Loot extends Model {
      * Get the reward attached to the loot entry.
      */
     public function reward() {
-        switch ($this->rewardable_type) {
-            case 'Item':
-                return $this->belongsTo(Item::class, 'rewardable_id');
-            case 'ItemRarity':
-                return $this->belongsTo(Item::class, 'rewardable_id');
-            case 'Currency':
-                return $this->belongsTo(Currency::class, 'rewardable_id');
-            case 'LootTable':
-                return $this->belongsTo(LootTable::class, 'rewardable_id');
-            case 'ItemCategory':
-                return $this->belongsTo(ItemCategory::class, 'rewardable_id');
-            case 'ItemCategoryRarity':
-                return $this->belongsTo(ItemCategory::class, 'rewardable_id');
-            case 'None':
-                // Laravel requires a relationship instance to be returned (cannot return null), so returning one that doesn't exist here.
-                return $this->belongsTo(self::class, 'rewardable_id', 'loot_table_id')->whereNull('loot_table_id');
-        }
-
-        return null;
+        return $this->morphTo('reward', 'rewardable_type', 'rewardable_id');
+        // 'None' is implicitly handled by morphTo.
     }
 }

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -3,14 +3,13 @@
 namespace App\Models\Prompt;
 
 use App\Models\Model;
-use App\Models\Reward\Reward;
 use App\Models\Submission\Submission;
 use App\Traits\Limitable;
 use App\Traits\Rewardable;
 use Carbon\Carbon;
 
 class Prompt extends Model {
-    use Rewardable, Limitable;
+    use Limitable, Rewardable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/Prompt/Prompt.php
+++ b/app/Models/Prompt/Prompt.php
@@ -5,9 +5,13 @@ namespace App\Models\Prompt;
 use App\Models\Model;
 use App\Models\Reward\Reward;
 use App\Models\Submission\Submission;
+use App\Traits\Limitable;
+use App\Traits\Rewardable;
 use Carbon\Carbon;
 
 class Prompt extends Model {
+    use Rewardable, Limitable;
+
     /**
      * The attributes that are mass assignable.
      *
@@ -76,13 +80,6 @@ class Prompt extends Model {
      */
     public function category() {
         return $this->belongsTo(PromptCategory::class, 'prompt_category_id');
-    }
-
-    /**
-     * Get the rewards attached to this prompt.
-     */
-    public function rewards() {
-        return $this->morphMany(Reward::class, 'object', 'object_model', 'object_id');
     }
 
     /**********************************************************************************************

--- a/app/Models/Reward/Reward.php
+++ b/app/Models/Reward/Reward.php
@@ -29,7 +29,7 @@ class Reward extends Model {
     protected $casts = [
         'data' => 'array',
     ];
-    
+
     /**
      * The relationships that should always be loaded.
      *

--- a/app/Models/Reward/Reward.php
+++ b/app/Models/Reward/Reward.php
@@ -29,6 +29,15 @@ class Reward extends Model {
     protected $casts = [
         'data' => 'array',
     ];
+    
+    /**
+     * The relationships that should always be loaded.
+     *
+     * @var array
+     */
+    protected $with = [
+        'reward',
+    ];
 
     /**
      * Validation rules for reward creation.
@@ -67,6 +76,13 @@ class Reward extends Model {
     **********************************************************************************************/
 
     /**
+     * Get the object that this reward is attached to as something that morphMany will accept.
+     */
+    public function rewardable() {
+        return $this->morphTo('rewardable', 'object_model', 'object_id');
+    }
+
+    /**
      * Get the object that this reward is attached to.
      */
     public function object() {
@@ -77,14 +93,7 @@ class Reward extends Model {
      * Get the reward associated with this entry.
      */
     public function reward() {
-        $model = getAssetModelString(strtolower($this->rewardable_type));
-
-        if (!class_exists($model)) {
-            // Laravel requires a relationship instance to be returned (cannot return null), so returning one that doesn't exist here.
-            return $this->belongsTo(self::class, 'id', 'object_id')->whereNull('object_id');
-        }
-
-        return $this->belongsTo($model, 'rewardable_id');
+        return $this->morphTo('reward', 'rewardable_type', 'rewardable_id');
     }
 
     /**********************************************************************************************
@@ -94,20 +103,22 @@ class Reward extends Model {
     **********************************************************************************************/
 
     /**
-     * checks if a certain object has any rewards.
+     * Checks if a certain object has any rewards.
+     * This is kept for backwards compatibility, and forwards to the helper function.
      *
      * @param mixed $object
      */
     public static function hasRewards($object) {
-        return self::where('object_model', get_class($object))->where('object_id', $object->id)->exists();
+        return hasRewards($object);
     }
 
     /**
-     * get the rewards of a certain object.
+     * Get the rewards of a certain object.
+     * This is kept for backwards compatibility, and forwards to the helper function.
      *
      * @param mixed $object
      */
     public static function getRewards($object) {
-        return self::where('object_model', get_class($object))->where('object_id', $object->id)->get();
+        return getRewards($object);
     }
 }

--- a/app/Models/Shop/Shop.php
+++ b/app/Models/Shop/Shop.php
@@ -4,9 +4,12 @@ namespace App\Models\Shop;
 
 use App\Models\Item\Item;
 use App\Models\Model;
+use App\Traits\Limitable;
 use Carbon\Carbon;
 
 class Shop extends Model {
+    use Limitable;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -61,7 +61,7 @@ class AppServiceProvider extends ServiceProvider {
         // Take all the model strings above and pair them with their class base name
         $modelStrings = array_map('getAssetModelString', array_map('strtolower', array_values($models)));
         // Finally, combine it all into a final morph map of alias => model string
-        $morphMap = array_merge($morphMap, array_combine(array_map(fn($model) => class_basename($model), $modelStrings), $modelStrings));
+        $morphMap = array_merge($morphMap, array_combine(array_map(fn ($model) => class_basename($model), $modelStrings), $modelStrings));
 
         Relation::morphMap($morphMap);
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -63,8 +63,6 @@ class AppServiceProvider extends ServiceProvider {
         // Finally, combine it all into a final morph map of alias => model string
         $morphMap = array_merge($morphMap, array_combine(array_map(fn ($model) => class_basename($model), $modelStrings), $modelStrings));
 
-
-
         Relation::morphMap($morphMap);
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Providers\Socialite\ToyhouseProvider;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
@@ -51,6 +52,18 @@ class AppServiceProvider extends ServiceProvider {
         });
 
         $this->bootToyhouseSocialite();
+
+        // Set custom polymorphic types for rewards and limits dynamically based on asset keys
+        // Merge both kinds of asset arrays, all of the limit types, and all of the loot types into one array
+        $models = array_unique(array_merge(getAssetKeys(), getAssetKeys(true), array_keys(config('lorekeeper.limits.limit_types'), array_map('strtolower', array_keys(config('lorekeeper.loot_types'))))));
+        // Create the initial morph map by feeding the above into getAssetModelString()
+        $morphMap = array_combine(array_values($models), array_map('getAssetModelString', array_values($models)));
+        // Take all the model strings above and pair them with their class base name
+        $modelStrings = array_map('getAssetModelString', array_map('strtolower', array_values($models)));
+        // Finally, combine it all into a final morph map of alias => model string
+        $morphMap = array_merge($morphMap, array_combine(array_map(fn($model) => class_basename($model), $modelStrings), $modelStrings));
+
+        Relation::morphMap($morphMap);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -55,13 +55,15 @@ class AppServiceProvider extends ServiceProvider {
 
         // Set custom polymorphic types for rewards and limits dynamically based on asset keys
         // Merge both kinds of asset arrays, all of the limit types, and all of the loot types into one array
-        $models = array_unique(array_merge(getAssetKeys(), getAssetKeys(true), array_keys(config('lorekeeper.limits.limit_types'), array_map('strtolower', array_keys(config('lorekeeper.loot_types'))))));
+        $models = array_unique(array_merge(getAssetKeys(), getAssetKeys(true), array_keys(config('lorekeeper.limits.limit_types')), array_map('strtolower', array_keys(config('lorekeeper.loot_types')))));
         // Create the initial morph map by feeding the above into getAssetModelString()
         $morphMap = array_combine(array_values($models), array_map('getAssetModelString', array_values($models)));
         // Take all the model strings above and pair them with their class base name
         $modelStrings = array_map('getAssetModelString', array_map('strtolower', array_values($models)));
         // Finally, combine it all into a final morph map of alias => model string
         $morphMap = array_merge($morphMap, array_combine(array_map(fn($model) => class_basename($model), $modelStrings), $modelStrings));
+
+
 
         Relation::morphMap($morphMap);
     }

--- a/app/Services/LimitManager.php
+++ b/app/Services/LimitManager.php
@@ -44,7 +44,7 @@ class LimitManager extends Service {
                     throw new \Exception('You must be logged in to complete this action.');
                 }
 
-                if ($user->unlockedLimits()->where('object_model', get_class($object))->where('object_id', $object->id)->exists()) {
+                if (hasUnlockedLimits($user, $object)) {
                     return true;
                 }
             }

--- a/app/Services/LimitService.php
+++ b/app/Services/LimitService.php
@@ -42,7 +42,7 @@ class LimitService extends Service {
                 throw new \Exception('Object not found.');
             }
 
-            $limits = hasLimits($object) ? getLimits($object) : [];
+            $limits = $object->limits;
             if (count($limits) > 0) {
                 $limits->each(function ($limit) {
                     $limit->delete();

--- a/app/Traits/Limitable.php
+++ b/app/Traits/Limitable.php
@@ -8,7 +8,6 @@ use App\Models\Limit\Limit;
  * Add this trait to any model that you want to have limits.
  */
 trait Limitable {
-
     public function limits() {
         return $this->morphMany(Limit::class, 'limitable', 'object_model', 'object_id');
     }
@@ -16,5 +15,4 @@ trait Limitable {
     public function getHasLimitsAttribute() {
         return $this->limits->count() !== 0;
     }
-
 }

--- a/app/Traits/Limitable.php
+++ b/app/Traits/Limitable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Limit\Limit;
+
+/**
+ * Add this trait to any model that you want to have limits.
+ */
+trait Limitable {
+
+    public function limits() {
+        return $this->morphMany(Limit::class, 'limitable', 'object_model', 'object_id');
+    }
+
+    public function getHasLimitsAttribute() {
+        return $this->limits->count() !== 0;
+    }
+
+}

--- a/app/Traits/Rewardable.php
+++ b/app/Traits/Rewardable.php
@@ -8,7 +8,6 @@ use App\Models\Reward\Reward;
  * Add this trait to any model that you want to have limits.
  */
 trait Rewardable {
-
     public function rewards() {
         return $this->morphMany(Reward::class, 'rewardable', 'object_model', 'object_id');
     }
@@ -16,5 +15,4 @@ trait Rewardable {
     public function getHasRewardsAttribute() {
         return $this->rewards->count() !== 0;
     }
-
 }

--- a/app/Traits/Rewardable.php
+++ b/app/Traits/Rewardable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Reward\Reward;
+
+/**
+ * Add this trait to any model that you want to have limits.
+ */
+trait Rewardable {
+
+    public function rewards() {
+        return $this->morphMany(Reward::class, 'rewardable', 'object_model', 'object_id');
+    }
+
+    public function getHasRewardsAttribute() {
+        return $this->rewards->count() !== 0;
+    }
+
+}

--- a/config/lorekeeper/loot_types.php
+++ b/config/lorekeeper/loot_types.php
@@ -2,7 +2,7 @@
 
 /**
  * These are the loot types that can be found in a loot table or similar, similar to getAssetKeys().
- * 
+ *
  * Listing them in a config file appeared to be the most lightweight solution to storing them.
  * 'None' is implicitly handled by morphTo().
  */
@@ -13,5 +13,5 @@ return [
     'Currency',
     'LootTable',
     'ItemCategory',
-    'ItemCategoryRarity'
+    'ItemCategoryRarity',
 ];

--- a/config/lorekeeper/loot_types.php
+++ b/config/lorekeeper/loot_types.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * These are the loot types that can be found in a loot table or similar, similar to getAssetKeys().
+ * 
+ * Listing them in a config file appeared to be the most lightweight solution to storing them.
+ * 'None' is implicitly handled by morphTo().
+ */
+
+return [
+    'Item',
+    'ItemRarity',
+    'Currency',
+    'LootTable',
+    'ItemCategory',
+    'ItemCategoryRarity'
+];

--- a/resources/views/prompts/_prompt_entry.blade.php
+++ b/resources/views/prompts/_prompt_entry.blade.php
@@ -59,7 +59,7 @@
                     </tbody>
                 </table>
             @endif
-            @if (count(getLimits($prompt)))
+            @if ($prompt->limits)
                 <hr />
                 @include('widgets._limits', [
                     'object' => $prompt,

--- a/resources/views/widgets/_add_limits.blade.php
+++ b/resources/views/widgets/_add_limits.blade.php
@@ -5,7 +5,7 @@
     $limitTypes = collect(config('lorekeeper.limits.limit_types'))->map(function ($value, $key) {
         return $value['name'];
     });
-    $limits = hasLimits($object) ? getLimits($object) : null;
+    $limits = $object->limits;
 
     $prompts = \App\Models\Prompt\Prompt::orderBy('name')->pluck('name', 'id')->toArray();
     $items = \App\Models\Item\Item::orderBy('name')->pluck('name', 'id')->toArray();

--- a/resources/views/widgets/_limits.blade.php
+++ b/resources/views/widgets/_limits.blade.php
@@ -2,7 +2,7 @@
     $limitTypes = collect(config('lorekeeper.limits.limit_types'))->map(function ($value, $key) {
         return $value['name'];
     });
-    $limits = hasLimits($object) ? getLimits($object) : null;
+    $limits = $object->limits;
     if (!isset($hideUnlock)) {
         $hideUnlock = false;
     }
@@ -11,7 +11,7 @@
     }
 @endphp
 
-@if ($limits)
+@if (count($limits))
     @if (!isset($compact) || !$compact)
         <h4 class="my-3">{!! $object->displayName !!}'s Requirements</h4>
         <p>


### PR DESCRIPTION
I'm back at it again with another big ol' refactor! This time, I have changed the Limit, Reward, and Loot models to be _actually_ polymorphic.

### "Hey Toko, what does that even mean?"

They're not very prevalent in LK, so I'd like to take some time to explain the concept of [**polymorphism**](https://laravel.com/docs/10.x/eloquent-relationships#polymorphic-relationships) and how it applies to us.

In the `Limit` model, we have [an if statement](https://github.com/lk-arpg/lorekeeper/blob/18820abc77079c5ced8df9c24a17f35df16350fd/app/Models/Limit/Limit.php#L43) that compares the value of `limit_type` to certain strings. Based on those certain strings, it will return a different model, such as an `Item` vs a `Currency`. These relationships with "changing" model types are called a **polymorphic relationship**. 

The problem is that, all this time, we have essentially been reinventing the wheel -- and to our detriment. 

The if statement with `limit_type` is evaluated at runtime. What this means is that Laravel can not pull the reward ahead of time. More or less, every time the `limit()` relationship is called, it has to re-query the database. In some cases, this can lead to a massive amount of duplicate queries, when either processing limits or displaying them. It's also just generally inefficient, and requires a lot of strange workarounds.

Fortunately, Laravel provides [some excellent ways](https://laravel.com/docs/10.x/eloquent-relationships#one-to-many-polymorphic-relations) for us to create "one-to-many" polymorphic relationship the _proper_ way. By using relationships such as `morphTo()` instead of `belongsTo()`, we can define these relationships in a way that _can_ be eager loaded and overall handled far more simply.

As part of this, I have also added "Rewardable" and "Limitable" traits. A trait is basically just a shorthand saying, "hey, attach these methods onto this model". These allow us to load the limits and rewards attached to any given object with an actual model relationship, and should be added to anything that uses limits/rewards.

---

Here is a summary of all the changes that this PR makes. As always, I tried to add good inline comments explaining everything, but I figured this couldn't hurt too. _**I have bolded/italicized any changes that may require changes to existing extensions/custom code.**_

### Morph Map
- A dynamically constructed [morph map](https://laravel.com/docs/10.x/eloquent-relationships#custom-polymorphic-types) has been added to the boot() method in AppServiceProvider.
- This directly maps aliases (i.e., 'item', 'currency') with a model string (i.e., `\App\Models\Item\Item` and `\App\Models\Currency\Currency` in a polymorphic model relationship.
	- This way, we do not need to modify the `rewardable_type`, etc in existing tables to make them polymorphic.
- Additional logic (mostly to do with limits and loot tables) has been added to `getAssetModelString()` to assist with converting aliases to their model strings. 
    - _**Please be mindful to preserve the new code when merging changes in AssetHelpers.**_
	- Based on your extensions or custom code, **you may need to add your own logic to `getAssetModelString()` as well.** More details below.

### Limits
- The limit() relationship on the Limit is now polymorphic. It finds the appropriate model based on the morph map.
	- _**Limit types outside of core will need to be added to `getAssetModelString`.**_
	- Essentially, the if statement logic that matches the `limit_type` to the model needs to be moved to the switch statement in `getAssetModelString`. 
	- If you have additional logic that happens after the belongsTo(), it will need to be added as a constraint.
- A new value for `dynamic` has been added to getAssetModelString() to account for the above.
- The new trait `Limitable` has been added. _**The Limitable trait must be added to any model that uses limits.**_
	- You can view the Prompt model as an example of how to implement this.
- The old object relationship has been preserved for backwards compatibility. `limitable()` and `object()` can be used interchangeably.
- Various versions of the `getLimits()` and `hasLimits()` methods have been changed to leverage the new relationship.
- The `limit()` relationship is always eager loaded (because you're basically going to need to retrieve it every time anyway).

To make it super clear what changes are required for custom limit types, here is an example with the `user_level` and `character_level` limit types from Claymores & Companions:
<img width="5456" height="1858" alt="image" src="https://github.com/user-attachments/assets/484dc7fd-1420-43b9-b791-d2c098d5eb07" />

### Rewards
- The reward() relationship on the Reward is now polymorphic. It finds the appropriate model based on the morph map.
	- You almost certainly already have all the required logic for this in `getAssetModelString()` and probably don't need to do anything.
	- However, if you run into errors with the reward relationship, it may be worth verifying.
- The new trait `Rewardable` has been added. _**The Rewardable trait must be added to any model that uses rewards.**_ 
	- You can view the Prompt model as an example of how to implement this.
- The old object relationship has been preserved for backwards compatibility. `rewardable()` and `object()` can be used interchangeably.
- Various versions of the `getRewards()` and `hasRewards()` methods have been changed to leverage the new relationship.
- The `reward()` relationship is always eager loaded (see above).

### Prompts
- Prompts have had the Limitable and Rewardable traits added to them.
- rewards() has been removed from the Prompt model, as it is now redundant.
- Eager loading has been added in various places to leverage the new traits.

### Loot Tables
- The reward relation on the Loot model is now polymorphic.
- **Extension/custom loot types must be listed in the new file `config/loot_types.php`.** These are used in building the morph map. They will be added similarly to custom limit types.
- A new value for `itemcategory` and `itemcategoryrarity` has been added to getAssetModelString() to account for the above.
- I didn't refactor the dropdowns in the create_edit_loot_table blade to use the config. I considered it, but it felt a little out of scope. It could be another PR at a later date...?

...and I think that covers everything! Thanks for taking the time to read this.