### PR TITLE
fix(galleries): speed up gallery load time

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -38,7 +38,12 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getGalleryIndex() {
-        $galleries = Gallery::whereNull('parent_id')->active()->sort()->with('children')->withCount('submissions', 'children');
+        $galleries = Gallery::whereNull('parent_id')
+            ->active()
+            ->sort()
+            ->with(['children' => function ($q) {
+                $q->visible();
+            }])->withCount('submissions', 'children');
 
         return view('galleries.index', [
             'galleries'       => $galleries->paginate(10),
@@ -100,9 +105,9 @@ class GalleryController extends Controller {
 
         return view('galleries.gallery', [
             'gallery'          => $gallery,
-            'submissions'      => $query->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
+            'submissions'      => $query->with('collaborators', 'participants')->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
             'prompts'          => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::where('gallery_id', $gallery->id)->withOnly('prompt')->visible(Auth::user() ?? null)->whereNotNull('prompt_id')->select('prompt_id')->distinct()->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
-            'childSubmissions' => $gallery->through('children')->has('submissions')->visible()->withDisplayData(Auth::user() ?? null),
+            'childSubmissions' => $gallery->childSubmissions()->with('gallery', 'collaborators', 'participants')->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
             'galleryPage'      => true,
             'sideGallery'      => $gallery,
         ]);
@@ -156,7 +161,7 @@ class GalleryController extends Controller {
         }
 
         return view('galleries.showall', [
-            'submissions' => $query->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
+            'submissions' => $query->with('collaborators', 'participants')->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
             'prompts'     => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::visible(Auth::user() ?? null)->accepted()->withOnly('prompt')->whereNotNull('prompt_id')->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
             'galleryPage' => false,
         ]);

--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -100,9 +100,9 @@ class GalleryController extends Controller {
 
         return view('galleries.gallery', [
             'gallery'          => $gallery,
-            'submissions'      => $query->paginate(20)->appends($request->query()),
+            'submissions'      => $query->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
             'prompts'          => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::where('gallery_id', $gallery->id)->withOnly('prompt')->visible(Auth::user() ?? null)->whereNotNull('prompt_id')->select('prompt_id')->distinct()->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
-            'childSubmissions' => $gallery->through('children')->has('submissions')->visible(),
+            'childSubmissions' => $gallery->through('children')->has('submissions')->visible()->withDisplayData(Auth::user() ?? null),
             'galleryPage'      => true,
             'sideGallery'      => $gallery,
         ]);
@@ -156,7 +156,7 @@ class GalleryController extends Controller {
         }
 
         return view('galleries.showall', [
-            'submissions' => $query->paginate(20)->appends($request->query()),
+            'submissions' => $query->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
             'prompts'     => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::visible(Auth::user() ?? null)->accepted()->withOnly('prompt')->whereNotNull('prompt_id')->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
             'galleryPage' => false,
         ]);
@@ -170,7 +170,7 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getSubmission($id) {
-        $submission = GallerySubmission::where('id', $id)->with('gallery', 'participants', 'characters')->first();
+        $submission = GallerySubmission::where('id', $id)->with('gallery', 'participants', 'characters')->withDisplayData(Auth::user() ?? null)->first();
         if (!$submission) {
             abort(404);
         }
@@ -222,7 +222,7 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getSubmissionLog($id) {
-        $submission = GallerySubmission::where('id', $id)->with('participants')->without('favorites', 'comments')->first();
+        $submission = GallerySubmission::where('id', $id)->with('participants')->first();
         if (!$submission) {
             abort(404);
         }
@@ -253,7 +253,7 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getUserSubmissions(Request $request, $type) {
-        $submissions = GallerySubmission::userSubmissions(Auth::user())->with('gallery')->without('favorites', 'comments');
+        $submissions = GallerySubmission::userSubmissions(Auth::user())->with('gallery');
         if (!$type) {
             $type = 'Pending';
         }
@@ -281,6 +281,12 @@ class GalleryController extends Controller {
         }
         $gallery = Gallery::find($id);
         $closed = !Settings::get('gallery_submissions_open');
+        $characters = Character::visible(Auth::user())
+            ->myo(0)
+            ->orderBy('slug', 'DESC')
+            ->get()
+            ->pluck('fullName', 'slug')
+            ->toArray();
 
         return view('galleries.create_edit_submission', [
             'closed' => $closed,
@@ -292,6 +298,7 @@ class GalleryController extends Controller {
             'currency'    => Currency::find(Settings::get('group_currency')),
             'galleryPage' => true,
             'sideGallery' => $gallery,
+            'characters' => $characters,
         ]));
     }
 
@@ -306,7 +313,7 @@ class GalleryController extends Controller {
         if (!Auth::check()) {
             abort(404);
         }
-        $submission = GallerySubmission::where('id', $id)->with('gallery')->with('participants', 'characters')->without('comments', 'favorites')->first();
+        $submission = GallerySubmission::where('id', $id)->with('gallery', 'participants', 'characters')->first();
         if (!$submission || $submission->status == 'Rejected') {
             abort(404);
         }
@@ -315,6 +322,12 @@ class GalleryController extends Controller {
         if (!$isMod && !$isOwner) {
             abort(404);
         }
+        $characters = Character::visible(Auth::user())
+            ->myo(0)
+            ->orderBy('slug', 'DESC')
+            ->get()
+            ->pluck('fullName', 'slug')
+            ->toArray();
 
         // Show inactive prompts in the event of being edited by an admin after acceptance
         $prompts = Auth::user()->hasPower('manage_submissions') && $submission->status == 'Pending' ? Prompt::query() : Prompt::active();
@@ -329,6 +342,7 @@ class GalleryController extends Controller {
             'currency'       => Currency::find(Settings::get('group_currency')),
             'galleryPage'    => true,
             'sideGallery'    => $submission->gallery,
+            'characters' => $characters,
         ]);
     }
 

--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -298,7 +298,7 @@ class GalleryController extends Controller {
             'currency'    => Currency::find(Settings::get('group_currency')),
             'galleryPage' => true,
             'sideGallery' => $gallery,
-            'characters' => $characters,
+            'characters'  => $characters,
         ]));
     }
 
@@ -342,7 +342,7 @@ class GalleryController extends Controller {
             'currency'       => Currency::find(Settings::get('group_currency')),
             'galleryPage'    => true,
             'sideGallery'    => $submission->gallery,
-            'characters' => $characters,
+            'characters'     => $characters,
         ]);
     }
 

--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -38,7 +38,7 @@ class GalleryController extends Controller {
      * @return \Illuminate\Contracts\Support\Renderable
      */
     public function getGalleryIndex() {
-        $galleries = Gallery::whereNull('parent_id')->active()->sort()->with('children', 'children.submissions', 'submissions')->withCount('submissions', 'children');
+        $galleries = Gallery::whereNull('parent_id')->active()->sort()->with('children')->withCount('submissions', 'children');
 
         return view('galleries.index', [
             'galleries'       => $galleries->paginate(10),
@@ -61,7 +61,7 @@ class GalleryController extends Controller {
             abort(404);
         }
 
-        $query = GallerySubmission::where('gallery_id', $gallery->id)->visible(Auth::check() ? Auth::user() : null);
+        $query = GallerySubmission::where('gallery_id', $gallery->id)->visible(Auth::user() ?? null);
         $sort = $request->only(['sort']);
 
         if ($request->get('title')) {
@@ -102,7 +102,7 @@ class GalleryController extends Controller {
             'gallery'          => $gallery,
             'submissions'      => $query->paginate(20)->appends($request->query()),
             'prompts'          => [0 => 'Any Prompt'] + Prompt::whereIn('id', GallerySubmission::where('gallery_id', $gallery->id)->withOnly('prompt')->visible(Auth::user() ?? null)->whereNotNull('prompt_id')->select('prompt_id')->distinct()->pluck('prompt_id')->toArray())->orderBy('name')->pluck('name', 'id')->toArray(),
-            'childSubmissions' => $gallery->through('children')->has('submissions')->where('is_visible', 1)->where('status', 'Accepted'),
+            'childSubmissions' => $gallery->through('children')->has('submissions')->visible(),
             'galleryPage'      => true,
             'sideGallery'      => $gallery,
         ]);
@@ -118,7 +118,7 @@ class GalleryController extends Controller {
             abort(404);
         }
 
-        $query = GallerySubmission::visible(Auth::check() ? Auth::user() : null)->accepted();
+        $query = GallerySubmission::visible(Auth::user() ?? null)->accepted();
         $sort = $request->only(['sort']);
 
         if ($request->get('title')) {
@@ -203,6 +203,9 @@ class GalleryController extends Controller {
      */
     public function getSubmissionFavorites($id) {
         $submission = GallerySubmission::where('id', $id)->withOnly('favorites')->first();
+        if (!$submission) {
+            abort(404);
+        }
         $favorites = $submission->favorites()->with('user')->get();
 
         return view('galleries._submission_favorites', [

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -28,8 +28,8 @@ class HomeController extends Controller {
      */
     public function getIndex() {
         if (config('lorekeeper.extensions.show_all_recent_submissions.enable')) {
-            $query = GallerySubmission::visible(Auth::check() ? Auth::user() : null)->accepted()->orderBy('created_at', 'DESC');
-            $gallerySubmissions = $query->get()->take(8);
+            $query = GallerySubmission::visible(Auth::user() ?? null)->accepted()->orderBy('created_at', 'DESC');
+            $gallerySubmissions = $query->take(8)->withDisplayData(Auth::user() ?? null)->get();
         } else {
             $gallerySubmissions = [];
         }

--- a/app/Http/Controllers/Users/UserController.php
+++ b/app/Http/Controllers/Users/UserController.php
@@ -313,7 +313,7 @@ class UserController extends Controller {
     public function getUserGallery(Request $request, $name) {
         return view('user.gallery', [
             'user'        => $this->user,
-            'submissions' => $this->user->gallerySubmissions()->visible(Auth::user() ?? null)->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
+            'submissions' => $this->user->gallerySubmissions()->visible(Auth::user() ?? null)->with('collaborators', 'participants')->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
         ]);
     }
 
@@ -328,7 +328,7 @@ class UserController extends Controller {
         return view('user.favorites', [
             'user'       => $this->user,
             'characters' => false,
-            'favorites'  => GallerySubmission::whereIn('id', $this->user->galleryFavorites()->pluck('gallery_submission_id')->toArray())->visible(Auth::user() ?? null)->favoritedCount(Auth::user() ?? null)->withCommentCount()->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()),
+            'favorites'  => GallerySubmission::whereIn('id', $this->user->galleryFavorites()->pluck('gallery_submission_id')->toArray())->visible(Auth::user() ?? null)->with('collaborators', 'participants')->favoritedCount(Auth::user() ?? null)->withCommentCount()->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()),
         ]);
     }
 
@@ -347,7 +347,7 @@ class UserController extends Controller {
         return view('user.favorites', [
             'user'       => $this->user,
             'characters' => true,
-            'favorites'  => $this->user->characters->count() ? GallerySubmission::whereIn('id', $userFavorites)->whereIn('id', GalleryCharacter::whereIn('character_id', $userCharacters)->pluck('gallery_submission_id')->toArray())->visible(Auth::user() ?? null)->favoritedCount(Auth::user() ?? null)->withCommentCount()->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()) : null,
+            'favorites'  => $this->user->characters->count() ? GallerySubmission::whereIn('id', $userFavorites)->whereIn('id', GalleryCharacter::whereIn('character_id', $userCharacters)->pluck('gallery_submission_id')->toArray())->visible(Auth::user() ?? null)->with('collaborators', 'participants')->favoritedCount(Auth::user() ?? null)->withCommentCount()->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()) : null,
         ]);
     }
 }

--- a/app/Http/Controllers/Users/UserController.php
+++ b/app/Http/Controllers/Users/UserController.php
@@ -313,7 +313,7 @@ class UserController extends Controller {
     public function getUserGallery(Request $request, $name) {
         return view('user.gallery', [
             'user'        => $this->user,
-            'submissions' => $this->user->gallerySubmissions()->visible(Auth::user() ?? null)->paginate(20)->appends($request->query()),
+            'submissions' => $this->user->gallerySubmissions()->visible(Auth::user() ?? null)->withDisplayData(Auth::user() ?? null)->paginate(20)->appends($request->query()),
         ]);
     }
 
@@ -328,7 +328,7 @@ class UserController extends Controller {
         return view('user.favorites', [
             'user'       => $this->user,
             'characters' => false,
-            'favorites'  => GallerySubmission::whereIn('id', $this->user->galleryFavorites()->pluck('gallery_submission_id')->toArray())->visible(Auth::check() ? Auth::user() : null)->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()),
+            'favorites'  => GallerySubmission::whereIn('id', $this->user->galleryFavorites()->pluck('gallery_submission_id')->toArray())->visible(Auth::user() ?? null)->favoritedCount(Auth::user() ?? null)->withCommentCount()->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()),
         ]);
     }
 
@@ -347,7 +347,7 @@ class UserController extends Controller {
         return view('user.favorites', [
             'user'       => $this->user,
             'characters' => true,
-            'favorites'  => $this->user->characters->count() ? GallerySubmission::whereIn('id', $userFavorites)->whereIn('id', GalleryCharacter::whereIn('character_id', $userCharacters)->pluck('gallery_submission_id')->toArray())->visible(Auth::check() ? Auth::user() : null)->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()) : null,
+            'favorites'  => $this->user->characters->count() ? GallerySubmission::whereIn('id', $userFavorites)->whereIn('id', GalleryCharacter::whereIn('character_id', $userCharacters)->pluck('gallery_submission_id')->toArray())->visible(Auth::user() ?? null)->favoritedCount(Auth::user() ?? null)->withCommentCount()->orderBy('created_at', 'DESC')->paginate(20)->appends($request->query()) : null,
         ]);
     }
 }

--- a/app/Models/Gallery/Gallery.php
+++ b/app/Models/Gallery/Gallery.php
@@ -4,7 +4,6 @@ namespace App\Models\Gallery;
 
 use App\Models\Model;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Auth;
 
 class Gallery extends Model {
     /**
@@ -106,10 +105,10 @@ class Gallery extends Model {
 
     /**
      * Get the submissions that belong specifically
-     * to children of this gallery. 
+     * to children of this gallery.
      * (This is a builder, not a relation. Just put
-     * up here to be next to the submissions relation.)
-     * 
+     * up here to be next to the submissions relation.).
+     *
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function childSubmissions() {

--- a/app/Models/Gallery/Gallery.php
+++ b/app/Models/Gallery/Gallery.php
@@ -4,6 +4,7 @@ namespace App\Models\Gallery;
 
 use App\Models\Model;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
 
 class Gallery extends Model {
     /**
@@ -101,6 +102,18 @@ class Gallery extends Model {
      */
     public function submissions() {
         return $this->hasMany(GallerySubmission::class, 'gallery_id')->visible()->orderBy('created_at', 'DESC');
+    }
+
+    /**
+     * Get the submissions that belong specifically
+     * to children of this gallery. 
+     * (This is a builder, not a relation. Just put
+     * up here to be next to the submissions relation.)
+     * 
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function childSubmissions() {
+        return GallerySubmission::whereIn('gallery_id', $this->children->pluck('id'))->visible()->orderBy('created_at', 'DESC');
     }
 
     /**********************************************************************************************

--- a/app/Models/Gallery/GallerySubmission.php
+++ b/app/Models/Gallery/GallerySubmission.php
@@ -41,16 +41,7 @@ class GallerySubmission extends Model {
      * @var array
      */
     protected $with = [
-        'user', 'comments:id,commentable_type,commentable_id,type',
-    ];
-
-    /**
-     * 	The relationship counts that should be eager loaded on every query.
-     *
-     * @var array
-     */
-    protected $withCount = [
-        'favorites', 'userComments',
+        'user',
     ];
 
     /**
@@ -276,6 +267,75 @@ class GallerySubmission extends Model {
      */
     public function scopeSortNewest($query) {
         return $query->orderBy('id', 'DESC');
+    }
+
+    /**
+     * Scope a query to grab the scopes:
+     * favoritedCount, collaboratedBy, and withCommentCount.
+     * Intentionally its own scope with the included three
+     * left separate so the individual scopes can be used
+     * whenever/wherever needed.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithDisplayData($query, $user = null) {
+        return $query->favoritedCount($user)
+        ->collaboratedBy($user)
+        ->withCommentCount();
+    }
+
+    /**
+     * Scope a query to grab favorites_count as well as a
+     * favorited check if the user is logged in.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeFavoritedCount($query, $user = null) {
+        if ($user) {
+            return $query->withCount([
+                'favorites',
+                'favorites as favorited' => function ($q) use ($user) {
+                    $q->where('user_id', $user->id);
+                }
+            ]);
+        }
+
+        return $query->withCount('favorites');
+    }
+
+    /**
+     * Scope a query to flag whether the given user is a collaborator.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param mixed|null                            $user
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeCollaboratedBy($query, $user = null) {
+        if (!$user) {
+            return $query;
+        }
+
+        return $query->withExists(['collaborators as is_collaborator' => function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        }]);
+    }
+
+    /**
+     * Scope a query to include User-User comment count.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeWithCommentCount($query) {
+        return $query->withCount('userComments');
     }
 
     /**********************************************************************************************

--- a/app/Models/Gallery/GallerySubmission.php
+++ b/app/Models/Gallery/GallerySubmission.php
@@ -41,7 +41,7 @@ class GallerySubmission extends Model {
      * @var array
      */
     protected $with = [
-        'user', 'collaborators', 'prompt:id,name,prefix', 'favorites', 'comments:id,commentable_type,commentable_id,type',
+        'user', 'comments:id,commentable_type,commentable_id,type',
     ];
 
     /**
@@ -50,7 +50,7 @@ class GallerySubmission extends Model {
      * @var array
      */
     protected $withCount = [
-        'favorites',
+        'favorites', 'userComments',
     ];
 
     /**
@@ -150,6 +150,13 @@ class GallerySubmission extends Model {
      */
     public function comments() {
         return $this->morphMany(Comment::class, 'commentable');
+    }
+
+    /**
+     * Get comments made on this submission of type User-User.
+     */
+    public function userComments() {
+        return $this->morphMany(Comment::class, 'commentable')->where('type', 'User-User');
     }
 
     /**********************************************************************************************

--- a/app/Models/Gallery/GallerySubmission.php
+++ b/app/Models/Gallery/GallerySubmission.php
@@ -283,8 +283,8 @@ class GallerySubmission extends Model {
      */
     public function scopeWithDisplayData($query, $user = null) {
         return $query->favoritedCount($user)
-        ->collaboratedBy($user)
-        ->withCommentCount();
+            ->collaboratedBy($user)
+            ->withCommentCount();
     }
 
     /**
@@ -302,7 +302,7 @@ class GallerySubmission extends Model {
                 'favorites',
                 'favorites as favorited' => function ($q) use ($user) {
                     $q->where('user_id', $user->id);
-                }
+                },
             ]);
         }
 

--- a/resources/views/galleries/_character_select.blade.php
+++ b/resources/views/galleries/_character_select.blade.php
@@ -1,10 +1,12 @@
 @php
-    $characters = \App\Models\Character\Character::visible(Auth::check() ? Auth::user() : null)
-        ->myo(0)
-        ->orderBy('slug', 'DESC')
-        ->get()
-        ->pluck('fullName', 'slug')
-        ->toArray();
+    if (!isset($characters)) {
+        $characters = \App\Models\Character\Character::visible(Auth::check() ? Auth::user() : null)
+            ->myo(0)
+            ->orderBy('slug', 'DESC')
+            ->get()
+            ->pluck('fullName', 'slug')
+            ->toArray();
+    }
 @endphp
 
 <div id="characterComponents" class="hide">

--- a/resources/views/galleries/_character_select_entry.blade.php
+++ b/resources/views/galleries/_character_select_entry.blade.php
@@ -1,10 +1,12 @@
 @php
-    $characters = \App\Models\Character\Character::visible(Auth::check() ? Auth::user() : null)
-        ->myo(0)
-        ->orderBy('slug', 'DESC')
-        ->get()
-        ->pluck('fullName', 'slug')
-        ->toArray();
+    if (!isset($characters)) {
+        $characters = \App\Models\Character\Character::visible(Auth::check() ? Auth::user() : null)
+            ->myo(0)
+            ->orderBy('slug', 'DESC')
+            ->get()
+            ->pluck('fullName', 'slug')
+            ->toArray();
+    }
 @endphp
 
 <div class="submission-character mb-3">

--- a/resources/views/galleries/_sidebar.blade.php
+++ b/resources/views/galleries/_sidebar.blade.php
@@ -16,7 +16,7 @@
         </li>
     @endif
 
-    @if ($galleryPage && $sideGallery->children->count())
+    @if ($galleryPage && $sideGallery->children()->visible()->exists())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->name }}: Sub-Galleries</div>
             @foreach ($sideGallery->children()->visible()->get() as $child)
@@ -25,7 +25,7 @@
         </li>
     @endif
 
-    @if ($galleryPage && $sideGallery->siblings() && $sideGallery->siblings->count())
+    @if ($galleryPage && $sideGallery->siblings() && $sideGallery->siblings()->visible()->exists())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->parent->name }}: Sub-Galleries</div>
             @foreach ($sideGallery->siblings()->visible()->get() as $sibling)
@@ -34,7 +34,7 @@
         </li>
     @endif
 
-    @if ($galleryPage && $sideGallery->avunculi() && $sideGallery->avunculi->count())
+    @if ($galleryPage && $sideGallery->avunculi() && $sideGallery->avunculi()->visible()->exists())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->parent->parent->name }}: Sub-Galleries</div>
             @foreach ($sideGallery->avunculi()->visible()->get() as $avunculus)

--- a/resources/views/galleries/_sidebar.blade.php
+++ b/resources/views/galleries/_sidebar.blade.php
@@ -16,7 +16,9 @@
         </li>
     @endif
 
-    @if ($galleryPage && $sideGallery->children()->visible()->exists())
+    @if (
+        $galleryPage &&
+            $sideGallery->children()->visible()->exists())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->name }}: Sub-Galleries</div>
             @foreach ($sideGallery->children()->visible()->get() as $child)
@@ -25,7 +27,10 @@
         </li>
     @endif
 
-    @if ($galleryPage && $sideGallery->siblings() && $sideGallery->siblings()->visible()->exists())
+    @if (
+        $galleryPage &&
+            $sideGallery->siblings() &&
+            $sideGallery->siblings()->visible()->exists())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->parent->name }}: Sub-Galleries</div>
             @foreach ($sideGallery->siblings()->visible()->get() as $sibling)
@@ -34,7 +39,10 @@
         </li>
     @endif
 
-    @if ($galleryPage && $sideGallery->avunculi() && $sideGallery->avunculi()->visible()->exists())
+    @if (
+        $galleryPage &&
+            $sideGallery->avunculi() &&
+            $sideGallery->avunculi()->visible()->exists())
         <li class="sidebar-section">
             <div class="sidebar-section-header">{{ $sideGallery->parent->parent->name }}: Sub-Galleries</div>
             @foreach ($sideGallery->avunculi()->visible()->get() as $avunculus)

--- a/resources/views/galleries/_thumb.blade.php
+++ b/resources/views/galleries/_thumb.blade.php
@@ -1,11 +1,6 @@
 <div class="flex-fill text-center mb-1">
     <a href="{{ $submission->url }}">@include('widgets._gallery_thumb', ['submission' => $submission])</a>
-    @php
-        $thumb = $submission->imagePath . '/' . $submission->thumbnailFileName;
-        $dimensions = isset($submission->hash) && !isset($submission->content_warning) && is_file($thumb) ? getimagesize($thumb) : false;
-        $width = $dimensions ? $dimensions[0] : 200;
-    @endphp
-    <div class="mt-1 mx-auto" style="max-width:{{ max(200, $width) }}px; overflow: hidden; text-overflow: ellipsis;">
+    <div class="mt-1 mx-auto" style="max-width: 200px; overflow: hidden; text-overflow: ellipsis;">
         @if (isset($submission->content_warning))
             <p><span class="text-danger"><strong>Content Warning:</strong></span> {!! nl2br(htmlentities($submission->content_warning)) !!}</p>
         @endif

--- a/resources/views/galleries/_thumb.blade.php
+++ b/resources/views/galleries/_thumb.blade.php
@@ -1,8 +1,8 @@
 <div class="flex-fill text-center mb-1">
     <a href="{{ $submission->url }}">@include('widgets._gallery_thumb', ['submission' => $submission])</a>
     @php
-        $thumb = $submission->imagePath.'/'.$submission->thumbnailFileName;
-        $dimensions = (isset($submission->hash) && !isset($submission->content_warning) && is_file($thumb)) ? getimagesize($thumb) : false;
+        $thumb = $submission->imagePath . '/' . $submission->thumbnailFileName;
+        $dimensions = isset($submission->hash) && !isset($submission->content_warning) && is_file($thumb) ? getimagesize($thumb) : false;
         $width = $dimensions ? $dimensions[0] : 200;
     @endphp
     <div class="mt-1 mx-auto" style="max-width:{{ max(200, $width) }}px; overflow: hidden; text-overflow: ellipsis;">

--- a/resources/views/galleries/_thumb.blade.php
+++ b/resources/views/galleries/_thumb.blade.php
@@ -16,7 +16,7 @@
         </a>
     </div>
     <div class="small">
-        @if (Auth::check() && ($submission->user->id != Auth::user()->id && !$submission->collaborators->contains('user_id', Auth::user()->id)) && $submission->isVisible)
+        @if (Auth::check() && ($submission->user->id != Auth::user()->id && !$submission->is_collaborator) && $submission->isVisible)
             {!! Form::open(['url' => '/gallery/favorite/' . $submission->id]) !!}
             @if (isset($gallery) && !$gallery)
                 In {!! $submission->gallery->displayName !!} ・
@@ -29,9 +29,9 @@
             @endif
             {{ $submission->favorites_count }} {!! Form::button('<i class="fas fa-star"></i> ', [
                 'style' => 'border:0; border-radius:.5em;',
-                'class' => $submission->favorites->contains('user_id', Auth::user()->id) ? 'btn-success' : '',
+                'class' => $submission->favorited ? 'btn-success' : '',
                 'data-toggle' => 'tooltip',
-                'title' => (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'Add to' : 'Remove from') . ' your Favorites',
+                'title' => (!$submission->favorited ? 'Add to' : 'Remove from') . ' your Favorites',
                 'type' => 'submit',
             ]) !!} ・
             {{ $submission->user_comments_count }}

--- a/resources/views/galleries/_thumb.blade.php
+++ b/resources/views/galleries/_thumb.blade.php
@@ -1,10 +1,10 @@
 <div class="flex-fill text-center mb-1">
     <a href="{{ $submission->url }}">@include('widgets._gallery_thumb', ['submission' => $submission])</a>
-    <?php if (isset($submission->hash) && !isset($submission->content_warning)) {
-        $width = Image::make($submission->imagePath . '/' . $submission->thumbnailFileName)->width();
-    } else {
-        $width = 200;
-    } ?>
+    @php
+        $thumb = $submission->imagePath.'/'.$submission->thumbnailFileName;
+        $dimensions = (isset($submission->hash) && !isset($submission->content_warning) && is_file($thumb)) ? getimagesize($thumb) : false;
+        $width = $dimensions ? $dimensions[0] : 200;
+    @endphp
     <div class="mt-1 mx-auto" style="max-width:{{ max(200, $width) }}px; overflow: hidden; text-overflow: ellipsis;">
         @if (isset($submission->content_warning))
             <p><span class="text-danger"><strong>Content Warning:</strong></span> {!! nl2br(htmlentities($submission->content_warning)) !!}</p>

--- a/resources/views/galleries/_thumb.blade.php
+++ b/resources/views/galleries/_thumb.blade.php
@@ -16,7 +16,7 @@
         </a>
     </div>
     <div class="small">
-        @if (Auth::check() && ($submission->user->id != Auth::user()->id && $submission->collaborators->where('user_id', Auth::user()->id)->first() == null) && $submission->isVisible)
+        @if (Auth::check() && ($submission->user->id != Auth::user()->id && !$submission->collaborators->contains('user_id', Auth::user()->id)) && $submission->isVisible)
             {!! Form::open(['url' => '/gallery/favorite/' . $submission->id]) !!}
             @if (isset($gallery) && !$gallery)
                 In {!! $submission->gallery->displayName !!} ・
@@ -29,12 +29,12 @@
             @endif
             {{ $submission->favorites_count }} {!! Form::button('<i class="fas fa-star"></i> ', [
                 'style' => 'border:0; border-radius:.5em;',
-                'class' => $submission->favorites->where('user_id', Auth::user()->id)->first() != null ? 'btn-success' : '',
+                'class' => $submission->favorites->contains('user_id', Auth::user()->id) ? 'btn-success' : '',
                 'data-toggle' => 'tooltip',
-                'title' => ($submission->favorites->where('user_id', Auth::user()->id)->first() == null ? 'Add to' : 'Remove from') . ' your Favorites',
+                'title' => (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'Add to' : 'Remove from') . ' your Favorites',
                 'type' => 'submit',
             ]) !!} ・
-            {{ $submission->comments->where('type', 'User-User')->count() }}
+            {{ $submission->user_comments_count }}
             <i class="fas fa-comment"></i>
             {!! Form::close() !!}
         @else
@@ -48,7 +48,7 @@
                 ・
             @endif
             {{ $submission->favorites_count }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・
-            {{ $submission->comments->where('type', 'User-User')->count() }} <i class="fas fa-comment" data-toggle="tooltip" title="Comments"></i>
+            {{ $submission->user_comments_count }} <i class="fas fa-comment" data-toggle="tooltip" title="Comments"></i>
         @endif
     </div>
 </div>

--- a/resources/views/galleries/create_edit_submission.blade.php
+++ b/resources/views/galleries/create_edit_submission.blade.php
@@ -119,12 +119,12 @@
                 <div id="characters" class="mb-3">
                     @if ($submission->id)
                         @foreach ($submission->characters as $character)
-                            @include('galleries._character_select_entry', ['character' => $character])
+                            @include('galleries._character_select_entry', ['character' => $character, 'characters' => $characters])
                         @endforeach
                     @endif
                     @if (old('slug'))
                         @foreach (array_unique(old('slug')) as $slug)
-                            @include('galleries._character_select_entry', ['character' => \App\Models\Character\Character::where('slug', $slug)->first()])
+                            @include('galleries._character_select_entry', ['character' => \App\Models\Character\Character::where('slug', $slug)->first(), 'characters' => $characters])
                         @endforeach
                     @endif
                 </div>
@@ -284,7 +284,7 @@
         </div>
         {!! Form::close() !!}
 
-        @include('galleries._character_select')
+        @include('galleries._character_select', ['characters' => $characters])
         <div class="collaborator-row hide mb-2">
             {!! Form::select('collaborator_id[]', $users, null, ['class' => 'form-control mr-2 collaborator-select', 'placeholder' => 'Select User']) !!}
             <div class="d-flex">

--- a/resources/views/galleries/gallery.blade.php
+++ b/resources/views/galleries/gallery.blade.php
@@ -70,11 +70,15 @@
 
         {!! $submissions->render() !!}
     @elseif($childSubmissions->count())
+        {!! $childSubmissions->render() !!}
+
         <div class="d-flex align-content-around flex-wrap mb-2">
-            @foreach ($childSubmissions->orderBy('created_at', 'DESC')->take(20)->get() as $submission)
+            @foreach ($childSubmissions as $submission)
                 @include('galleries._thumb', ['submission' => $submission, 'gallery' => false])
             @endforeach
         </div>
+
+        {!! $childSubmissions->render() !!}
     @else
         <p>No submissions found!</p>
     @endif

--- a/resources/views/galleries/gallery.blade.php
+++ b/resources/views/galleries/gallery.blade.php
@@ -71,7 +71,7 @@
         {!! $submissions->render() !!}
     @elseif($childSubmissions->count())
         <div class="d-flex align-content-around flex-wrap mb-2">
-            @foreach ($childSubmissions->orderBy('created_at', 'DESC')->get()->take(20) as $submission)
+            @foreach ($childSubmissions->orderBy('created_at', 'DESC')->take(20)->get() as $submission)
                 @include('galleries._thumb', ['submission' => $submission, 'gallery' => false])
             @endforeach
         </div>

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -62,8 +62,7 @@
                         @if ($gallery->submissions_count > 4)
                             <div class="text-right"><a href="{{ url('gallery/' . $gallery->id) }}">See More...</a></div>
                         @endif
-                    @elseif(
-                        $gallery->children_count && $gallery->childSubmissions()->exists())
+                    @elseif($gallery->children_count && $gallery->childSubmissions()->exists())
                         <div class="row">
                             @foreach ($gallery->childSubmissions()->with('gallery', 'collaborators', 'participants')->withDisplayData(Auth::user() ?? null)->limit(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -37,7 +37,7 @@
                                 @endif
                                 {{ $gallery->start_at && $gallery->end_at ? ' ・ ' : '' }}
                                 @if ($gallery->end_at)
-                                    <strong>Close{{ $gallery->end_at->isFuture() ? 's' : 'ed' }}: </strong>{!! pretty_date($gallery->end_at) !!}
+                                    <strong>Close{{ $gallery->end_at->isFuture() ? 's' : 'd' }}: </strong>{!! pretty_date($gallery->end_at) !!}
                                 @endif
                             @endif
                             {{ $gallery->children_count && (isset($gallery->start_at) || isset($gallery->end_at)) ? ' ・ ' : '' }}
@@ -53,7 +53,7 @@
                 <div class="card-body">
                     @if ($gallery->submissions_count)
                         <div class="row">
-                            @foreach ($gallery->submissions->take(4) as $submission)
+                            @foreach ($gallery->submissions()->limit(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => true])
                                 </div>
@@ -64,9 +64,9 @@
                         @endif
                     @elseif(
                         $gallery->children_count &&
-                            $gallery->through('children')->has('submissions')->where('is_visible', 1)->where('status', 'Accepted')->count())
+                            $gallery->through('children')->has('submissions')->exists())
                         <div class="row">
-                            @foreach ($gallery->through('children')->has('submissions')->where('is_visible', 1)->where('status', 'Accepted')->orderBy('created_at', 'DESC')->get()->take(4) as $submission)
+                            @foreach ($gallery->through('children')->has('submissions')->visible()->orderBy('created_at', 'DESC')->limit(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => false])
                                 </div>

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -43,7 +43,7 @@
                             {{ $gallery->children_count && (isset($gallery->start_at) || isset($gallery->end_at)) ? ' ・ ' : '' }}
                             @if ($gallery->children_count)
                                 Sub-galleries:
-                                @foreach ($gallery->children()->visible()->get() as $child)
+                                @foreach ($gallery->children as $child)
                                     {!! $child->displayName !!}{{ !$loop->last ? ', ' : '' }}
                                 @endforeach
                             @endif
@@ -53,7 +53,7 @@
                 <div class="card-body">
                     @if ($gallery->submissions_count)
                         <div class="row">
-                            @foreach ($gallery->submissions()->withDisplayData(Auth::user() ?? null)->limit(4)->get() as $submission)
+                            @foreach ($gallery->submissions()->with('collaborators', 'participants')->withDisplayData(Auth::user() ?? null)->limit(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => true])
                                 </div>
@@ -63,10 +63,9 @@
                             <div class="text-right"><a href="{{ url('gallery/' . $gallery->id) }}">See More...</a></div>
                         @endif
                     @elseif(
-                        $gallery->children_count &&
-                            $gallery->through('children')->has('submissions')->visible()->exists())
+                        $gallery->children_count && $gallery->childSubmissions()->exists())
                         <div class="row">
-                            @foreach ($gallery->through('children')->has('submissions')->visible()->withDisplayData(Auth::user() ?? null)->orderBy('created_at', 'DESC')->limit(4)->get() as $submission)
+                            @foreach ($gallery->childSubmissions()->with('gallery', 'collaborators', 'participants')->withDisplayData(Auth::user() ?? null)->limit(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => false])
                                 </div>

--- a/resources/views/galleries/index.blade.php
+++ b/resources/views/galleries/index.blade.php
@@ -53,7 +53,7 @@
                 <div class="card-body">
                     @if ($gallery->submissions_count)
                         <div class="row">
-                            @foreach ($gallery->submissions()->limit(4)->get() as $submission)
+                            @foreach ($gallery->submissions()->withDisplayData(Auth::user() ?? null)->limit(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => true])
                                 </div>
@@ -64,9 +64,9 @@
                         @endif
                     @elseif(
                         $gallery->children_count &&
-                            $gallery->through('children')->has('submissions')->exists())
+                            $gallery->through('children')->has('submissions')->visible()->exists())
                         <div class="row">
-                            @foreach ($gallery->through('children')->has('submissions')->visible()->orderBy('created_at', 'DESC')->limit(4)->get() as $submission)
+                            @foreach ($gallery->through('children')->has('submissions')->visible()->withDisplayData(Auth::user() ?? null)->orderBy('created_at', 'DESC')->limit(4)->get() as $submission)
                                 <div class="col-md-3 text-center align-self-center">
                                     @include('galleries._thumb', ['submission' => $submission, 'gallery' => false])
                                 </div>

--- a/resources/views/galleries/submission.blade.php
+++ b/resources/views/galleries/submission.blade.php
@@ -18,11 +18,11 @@
         <div class="float-right">
             @if (Auth::check())
                 {!! Form::open(['url' => '/gallery/favorite/' . $submission->id]) !!}
-                @if ($submission->user->id != Auth::user()->id && !$submission->collaborators->contains('user_id', Auth::user()->id) && $submission->isVisible)
+                @if ($submission->user->id != Auth::user()->id && !$submission->is_collaborator && $submission->isVisible)
                     {!! Form::button('<i class="fas fa-star"></i> ', [
-                        'class' => 'btn ' . (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'btn-outline-primary' : 'btn-primary'),
+                        'class' => 'btn ' . (!$submission->favorited ? 'btn-outline-primary' : 'btn-primary'),
                         'data-toggle' => 'tooltip',
-                        'title' => (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'Add to' : 'Remove from') . ' your Favorites',
+                        'title' => (!$submission->favorited ? 'Add to' : 'Remove from') . ' your Favorites',
                         'type' => 'submit',
                     ]) !!}
                 @endif
@@ -85,13 +85,13 @@
                                 <a class="float-right" href="{{ url('reports/new?url=') . $submission->url }}"><i class="fas fa-exclamation-triangle" data-toggle="tooltip" title="Click here to report this submission." style="opacity: 50%;"></i></a>
                             </h5>
                             <div class="float-right">
-                                @if (Auth::check() && ($submission->user->id != Auth::user()->id && !$submission->collaborators->contains('user_id', Auth::user()->id)) && $submission->isVisible)
+                                @if (Auth::check() && ($submission->user->id != Auth::user()->id && !$submission->is_collaborator) && $submission->isVisible)
                                     {!! Form::open(['url' => '/gallery/favorite/' . $submission->id]) !!}
                                     {{ $submission->favorites_count }} {!! Form::button('<i class="fas fa-star"></i> ', [
                                         'style' => 'border:0; border-radius:.5em;',
-                                        'class' => $submission->favorites->contains('user_id', Auth::user()->id) ? 'btn-success' : '',
+                                        'class' => $submission->favorited ? 'btn-success' : '',
                                         'data-toggle' => 'tooltip',
-                                        'title' => (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'Add to' : 'Remove from') . ' your Favorites',
+                                        'title' => (!$submission->favorited ? 'Add to' : 'Remove from') . ' your Favorites',
                                         'type' => 'submit',
                                     ]) !!} ・ {{ $submission->user_comments_count }} <i class="fas fa-comment"></i>
                                     {!! Form::close() !!}
@@ -133,7 +133,7 @@
                         <h5>Collaborators</h5>
                     </div>
                     <div class="card-body">
-                        @if ($submission->status == 'Pending' && Auth::check() && $submission->collaborators->contains('user_id', Auth::user()->id))
+                        @if ($submission->status == 'Pending' && Auth::check() && $submission->is_collaborator)
                             <p>Check that your role in the collaboration is correct as listed, and if not, make any changes. You can also remove yourself from the collaborator list if necessary. When you are done, or if the record is already accurate,
                                 press "submit" to make any changes and mark yourself as having approved. You will be able to edit this until the submission is approved.</p>
                             {!! Form::open(['url' => '/gallery/collaborator/' . $submission->id]) !!}

--- a/resources/views/galleries/submission.blade.php
+++ b/resources/views/galleries/submission.blade.php
@@ -96,8 +96,7 @@
                                     ]) !!} ・ {{ $submission->user_comments_count }} <i class="fas fa-comment"></i>
                                     {!! Form::close() !!}
                                 @else
-                                    {{ $submission->favorites_count }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・ {{ $submission->user_comments_count }} <i class="fas fa-comment"
-                                        data-toggle="tooltip" title="Comments"></i>
+                                    {{ $submission->favorites_count }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・ {{ $submission->user_comments_count }} <i class="fas fa-comment" data-toggle="tooltip" title="Comments"></i>
                                 @endif
                             </div>
                             In {!! $submission->gallery->displayName !!} ・ By {!! $submission->credits !!}

--- a/resources/views/galleries/submission.blade.php
+++ b/resources/views/galleries/submission.blade.php
@@ -18,11 +18,11 @@
         <div class="float-right">
             @if (Auth::check())
                 {!! Form::open(['url' => '/gallery/favorite/' . $submission->id]) !!}
-                @if ($submission->user->id != Auth::user()->id && $submission->collaborators->where('user_id', Auth::user()->id)->first() == null && $submission->isVisible)
+                @if ($submission->user->id != Auth::user()->id && !$submission->collaborators->contains('user_id', Auth::user()->id) && $submission->isVisible)
                     {!! Form::button('<i class="fas fa-star"></i> ', [
-                        'class' => 'btn ' . ($submission->favorites->where('user_id', Auth::user()->id)->first() == null ? 'btn-outline-primary' : 'btn-primary'),
+                        'class' => 'btn ' . (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'btn-outline-primary' : 'btn-primary'),
                         'data-toggle' => 'tooltip',
-                        'title' => ($submission->favorites->where('user_id', Auth::user()->id)->first() == null ? 'Add to' : 'Remove from') . ' your Favorites',
+                        'title' => (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'Add to' : 'Remove from') . ' your Favorites',
                         'type' => 'submit',
                     ]) !!}
                 @endif
@@ -43,8 +43,8 @@
                 By {!! $submission->credits !!}
             </div>
             <div class="col-md text-right">
-                {{ $submission->favorites_count }} Favorite{{ $submission->favorites_count != 1 ? 's' : '' }} ・ {{ $submission->comments->where('type', 'User-User')->count() }}
-                Comment{{ $submission->comments->where('type', 'User-User')->count() != 1 ? 's' : '' }}
+                {{ $submission->favorites_count }} Favorite{{ $submission->favorites_count != 1 ? 's' : '' }} ・ {{ $submission->user_comments_count }}
+                Comment{{ $submission->user_comments_count != 1 ? 's' : '' }}
             </div>
         </diV>
     </div>
@@ -85,18 +85,18 @@
                                 <a class="float-right" href="{{ url('reports/new?url=') . $submission->url }}"><i class="fas fa-exclamation-triangle" data-toggle="tooltip" title="Click here to report this submission." style="opacity: 50%;"></i></a>
                             </h5>
                             <div class="float-right">
-                                @if (Auth::check() && ($submission->user->id != Auth::user()->id && $submission->collaborators->where('user_id', Auth::user()->id)->first() == null) && $submission->isVisible)
+                                @if (Auth::check() && ($submission->user->id != Auth::user()->id && !$submission->collaborators->contains('user_id', Auth::user()->id)) && $submission->isVisible)
                                     {!! Form::open(['url' => '/gallery/favorite/' . $submission->id]) !!}
-                                    {{ $submission->favorites->count() }} {!! Form::button('<i class="fas fa-star"></i> ', [
+                                    {{ $submission->favorites_count }} {!! Form::button('<i class="fas fa-star"></i> ', [
                                         'style' => 'border:0; border-radius:.5em;',
-                                        'class' => $submission->favorites->where('user_id', Auth::user()->id)->first() != null ? 'btn-success' : '',
+                                        'class' => $submission->favorites->contains('user_id', Auth::user()->id) ? 'btn-success' : '',
                                         'data-toggle' => 'tooltip',
-                                        'title' => ($submission->favorites->where('user_id', Auth::user()->id)->first() == null ? 'Add to' : 'Remove from') . ' your Favorites',
+                                        'title' => (!$submission->favorites->contains('user_id', Auth::user()->id) ? 'Add to' : 'Remove from') . ' your Favorites',
                                         'type' => 'submit',
-                                    ]) !!} ・ {{ $submission->comments->where('type', 'User-User')->count() }} <i class="fas fa-comment"></i>
+                                    ]) !!} ・ {{ $submission->user_comments_count }} <i class="fas fa-comment"></i>
                                     {!! Form::close() !!}
                                 @else
-                                    {{ $submission->favorites->count() }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・ {{ $submission->comments->where('type', 'User-User')->count() }} <i class="fas fa-comment"
+                                    {{ $submission->favorites_count }} <i class="fas fa-star" data-toggle="tooltip" title="Favorites"></i> ・ {{ $submission->user_comments_count }} <i class="fas fa-comment"
                                         data-toggle="tooltip" title="Comments"></i>
                                 @endif
                             </div>
@@ -114,7 +114,7 @@
                                 @if ($submission->prompt_id)
                                     <strong>for</strong> {!! $submission->prompt->displayName !!}
                                 @endif
-                                @if ($submission->favorites->count())
+                                @if ($submission->favorites_count)
                                     ・ <a class="view-favorites" href="#">View Favorites</a>
                                 @endif
                                 <br />
@@ -133,7 +133,7 @@
                         <h5>Collaborators</h5>
                     </div>
                     <div class="card-body">
-                        @if ($submission->status == 'Pending' && Auth::check() && $submission->collaborators->where('user_id', Auth::user()->id)->first() != null)
+                        @if ($submission->status == 'Pending' && Auth::check() && $submission->collaborators->contains('user_id', Auth::user()->id))
                             <p>Check that your role in the collaboration is correct as listed, and if not, make any changes. You can also remove yourself from the collaborator list if necessary. When you are done, or if the record is already accurate,
                                 press "submit" to make any changes and mark yourself as having approved. You will be able to edit this until the submission is approved.</p>
                             {!! Form::open(['url' => '/gallery/collaborator/' . $submission->id]) !!}


### PR DESCRIPTION
Resolves issue #1510

First pass reduced 63k+ model load to ~200 models loaded on gallery index. `$with` and `$withCount` on models hydrates the eager load on *every single model retrieved* which is why large galleries had issues with load times. And then subsequent investigation and adjustments followed: it turned out the `->through()` query was building a heavy join in the database, which could be bypassed by simply making a single query builder that fetched child submissions by plucking children gallery IDs. Eager loads were kept where actually needed, and additional scopes were added - one scope consolidates them all while they all can be called individually for convenience if anyone wants to change it up.

Also cleaned up some redundancy: `->visible()` already checks for acceptance. `submissions()` relation already sorts in descending order. Made the sidebar queries match what they're meant to display, and replaced `->count()` with `->exists()` for efficiency.

At first I refactored the `Image::make()` into a native PHP function, which benchmarked much faster, but it was pointed out how the max is 200px anyways so I removed the whole `@php`  and let flex do its thing.

Some numbers from adding this specific eager load before the display data scope, after all the other stuff:
`->with('collaborators', 'participants')`
> **GALLERY INDEX**
> Before the eager load: 263 queries, 211 models, 1.37s
> After the eager load: 196 queries, 207 models, 976ms
> 
> **GALLERY PAGE**
> Before: 140 queries, 126 models, 945ms
> After: 88 queries, 115 models, 815ms
> 
> **CHILD SUBMISSION ONLY GALLERIES**
> Before: 161 queries, 141 models, 1.36s
> After: 121 queries, 139 models, 980ms
> 
> **ALL RECENT**
> Before: 132 queries, 111 models, 1.21s
> After: 92 queries, 111 models, 813ms

The one aspect to know for the future: even at ~200 models, a gallery index still had a 9 second load time. Upon further investigation, it was *only* the index and the individual gallery page where only child submissions were shown. Lesson learned is that a giant join query itself makes site load chug, which was subsequently resolved via a simpler query to gallery submissions directly in-model. (And it doesn't help that MySQL/MariaDB provisions 128M by default, but access to touching that varies by host provider and is only a bandaid - doesn't target the root issue.)

Oh also children submission-only galleries did not paginate. I added pagination for it, but wasn't entirely sure if the no-pagination was intentional, so it's free to just strip out.

PRing to v3 because I think enough sites are on v3/will be moving to v3 that have hefty enough galleries to benefit from this. I think this is as far as it can be refactored without changing DB schema itself, and from what I can tell the tables already have appropriate indices...

Thank you to Mark for helping test this and report back data to me so I could finish pinpointing and finetuning what exactly was causing the pages to load so slow. :)