### PR TITLE
fix: suppress duplicate security advisory for PKSA-mdq4-51ck-6kdq

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
                     "PKSA-mdq4-51ck-6kdq": "Hotfixed using custom sanitization middleware.",
                     "PKSA-8qx3-n5y5-vvnd": "Resolved in laravel/framework 10.48.23. Do not use wildcard validation with files in Laravel v8/Lorekeeper v2.",
                     "PKSA-3r5d-mb8f-1qw9": "Hotfixed using custom sanitization middleware, duplicate of PKSA-mdq4-51ck-6kdq",
+                    "PKSA-zwc5-qtrz-zm1n": "Hotfixed using custom sanitization middleware, duplicate of PKSA-mdq4-51ck-6kdq",
                     "PKSA-m5cs-t1y6-qpcs": "Lorekeeper core does not use temporary signed URLs from the storage driver. Avoid using temporary signed urls as part of custom changes."
                 }
             }


### PR DESCRIPTION
It's another duplicate of https://github.com/laravel/framework/security/advisories/GHSA-5vg9-5847-vvmq! hooray! I don't know why illuminate/mail has [their own special ID](https://packagist.org/security-advisories/PKSA-zwc5-qtrz-zm1n) for this advisory but it sure is blocking me from running `composer update` yet again!