### PR TITLE
fix: unable to remove images on features

### DIFF
--- a/app/Services/FeatureService.php
+++ b/app/Services/FeatureService.php
@@ -289,7 +289,7 @@ class FeatureService extends Service {
                 }
             }
 
-            $data = $this->populateData($data);
+            $data = $this->populateData($data, $feature);
 
             $image = null;
             if (isset($data['image']) && $data['image']) {


### PR DESCRIPTION
Fixes missing secondary argument that resulted in images not actually getting removed from features when the box is checked.