### PR TITLE
fix(traits): clarify the deletion modal

### DIFF
--- a/resources/views/admin/features/_delete_feature.blade.php
+++ b/resources/views/admin/features/_delete_feature.blade.php
@@ -1,8 +1,12 @@
 @if ($feature)
     {!! Form::open(['url' => 'admin/data/traits/delete/' . $feature->id]) !!}
 
-    <p>You are about to delete the trait <strong>{{ $feature->name }}</strong>. This is not reversible. If characters possessing this trait exist, you will not be able to delete this trait.</p>
-    <p>Are you sure you want to delete <strong>{{ $feature->name }}</strong>?</p>
+    <p>
+        You are about to delete the trait <strong>{{ $feature->name }}</strong>. This is not reversible. If characters <i>or</i> design updates possessing this trait exist, you will not be able to delete this trait.
+    </p>
+    <p>
+        Are you sure you want to delete <strong>{{ $feature->name }}</strong>?
+    </p>
 
     <div class="text-right">
         {!! Form::submit('Delete Trait', ['class' => 'btn btn-danger']) !!}


### PR DESCRIPTION
I've had enough clients baffled and ask me why they can't delete a trait when they've removed it from every single existing character on the site. I realized: the deletion modal isn't clear about this. It counts traits in design updates too. So this is just a very small wording change to mention that design updates are also counted.