### PR TITLE
fix: quick raffle is_active validation + winner optimization

### DIFF
--- a/app/Services/RaffleManager.php
+++ b/app/Services/RaffleManager.php
@@ -27,10 +27,6 @@ class RaffleManager extends Service {
      * @return int
      */
     public function addTickets($raffle, $data) {
-        if (!$raffle->is_active) {
-            throw new \Exception('Raffle is not currently active!');
-        }
-
         $count = 0;
         foreach ($data['user_id'] as $key=> $id) {
             if ($user = User::where('id', $id)->first()) {
@@ -57,13 +53,11 @@ class RaffleManager extends Service {
      * @return int
      */
     public function addTicket($user, $raffle, $count = 1) {
-        if (!$raffle->is_active) {
-            throw new \Exception('Raffle is not currently active!');
-        }
-
         if (!$user) {
             return 0;
         } elseif (!$raffle) {
+            return 0;
+        } elseif (!$raffle->is_active) {
             return 0;
         } elseif ($count == 0) {
             return 0;

--- a/app/Services/RaffleManager.php
+++ b/app/Services/RaffleManager.php
@@ -27,6 +27,10 @@ class RaffleManager extends Service {
      * @return int
      */
     public function addTickets($raffle, $data) {
+        if (!$raffle->is_active) {
+            throw new \Exception('Raffle is not currently active!');
+        }
+
         $count = 0;
         foreach ($data['user_id'] as $key=> $id) {
             if ($user = User::where('id', $id)->first()) {
@@ -53,6 +57,10 @@ class RaffleManager extends Service {
      * @return int
      */
     public function addTicket($user, $raffle, $count = 1) {
+        if (!$raffle->is_active) {
+            throw new \Exception('Raffle is not currently active!');
+        }
+
         if (!$user) {
             return 0;
         } elseif (!$raffle) {
@@ -197,13 +205,8 @@ class RaffleManager extends Service {
 
             $ticketCount--;
 
-            // remove tickets for the same user...I'm unsure how this is going to hold up with 3000 tickets,
-            foreach ($ticketPool as $key=> $ticket) {
-                if (($ticket->user_id != null && $ticket->user_id == $winner->user_id) || ($ticket->user_id == null && $ticket->alias == $winner->alias)) {
-                    $ticketPool->forget($key);
-                }
-            }
-            $ticketPool = $ticketPool->values();
+            // remove tickets for the same user
+            $ticketPool = $ticketPool->whereNotIn('user_id', $winner->user_id)->whereNotIn('alias', $winner->alias)->values();
             $ticketCount = $ticketPool->count();
         }
 


### PR DESCRIPTION
really simple fixes on v3:

- added validation to adding raffle tickets to check if a raffle is active. I noticed mostly everywhere that lets you add raffle tickets as rewards will never display inactive raffles, so I don't think it makes sense if users can still join an inactive raffle. It's absolutely possible if say, somehow, a raffle was made active and the ticket was added as a prompt reward, and then the raffle was set inactive or something of the sort- an user could still enter the inactive raffle.
- I think I optimized the code for removing a winner from the raffle pool when in the rolling loop.... it uses the `whereNotIn` query using the value stored in $winner before the next loop starts it over again. nulls in $winner->alias or $winner->user_id do not impact the function. please please please the 3000 ticket foreach statement was so funny to me I keep losing sleep over it