### PR TITLE
fix(currencies): missing text if both is_user_owned and is_character owned are true

### DIFF
--- a/resources/views/world/_currency_entry.blade.php
+++ b/resources/views/world/_currency_entry.blade.php
@@ -10,7 +10,7 @@
             @endif
         </h3>
         <div><strong>Displays as:</strong> {!! $currency->display(0) !!}</div>
-        <div><strong>Held by:</strong> <?php echo ucfirst(implode(' and ', ($currency->is_user_owned ? ['users'] : []) + ($currency->is_character_owned ? ['characters'] : []))); ?></div>
+        <div><strong>Held by:</strong> <?php echo implode(' and ', array_merge(($currency->is_user_owned ? ['Users'] : []), ($currency->is_character_owned ? ['Characters'] : []))); ?></div>
         <div class="world-entry-text parsed-text">
             {!! $currency->parsed_description !!}
         </div>

--- a/resources/views/world/_currency_entry.blade.php
+++ b/resources/views/world/_currency_entry.blade.php
@@ -10,7 +10,7 @@
             @endif
         </h3>
         <div><strong>Displays as:</strong> {!! $currency->display(0) !!}</div>
-        <div><strong>Held by:</strong> <?php echo implode(' and ', array_merge($currency->is_user_owned ? ['Users'] : [], $currency->is_character_owned ? ['Characters'] : [])); ?></div>
+        <div><strong>Held by:</strong> {{ implode(' and ', array_merge(($currency->is_user_owned ? ['Users'] : []), ($currency->is_character_owned ? ['Characters'] : []))) }}</div>
         <div class="world-entry-text parsed-text">
             {!! $currency->parsed_description !!}
         </div>

--- a/resources/views/world/_currency_entry.blade.php
+++ b/resources/views/world/_currency_entry.blade.php
@@ -10,7 +10,7 @@
             @endif
         </h3>
         <div><strong>Displays as:</strong> {!! $currency->display(0) !!}</div>
-        <div><strong>Held by:</strong> <?php echo implode(' and ', array_merge(($currency->is_user_owned ? ['Users'] : []), ($currency->is_character_owned ? ['Characters'] : []))); ?></div>
+        <div><strong>Held by:</strong> <?php echo implode(' and ', array_merge($currency->is_user_owned ? ['Users'] : [], $currency->is_character_owned ? ['Characters'] : [])); ?></div>
         <div class="world-entry-text parsed-text">
             {!! $currency->parsed_description !!}
         </div>

--- a/resources/views/world/_currency_entry.blade.php
+++ b/resources/views/world/_currency_entry.blade.php
@@ -10,7 +10,7 @@
             @endif
         </h3>
         <div><strong>Displays as:</strong> {!! $currency->display(0) !!}</div>
-        <div><strong>Held by:</strong> {{ implode(' and ', array_merge(($currency->is_user_owned ? ['Users'] : []), ($currency->is_character_owned ? ['Characters'] : []))) }}</div>
+        <div><strong>Held by:</strong> {{ implode(' and ', array_merge($currency->is_user_owned ? ['Users'] : [], $currency->is_character_owned ? ['Characters'] : [])) }}</div>
         <div class="world-entry-text parsed-text">
             {!! $currency->parsed_description !!}
         </div>


### PR DESCRIPTION
Turns out that if is_user_owned and is_character_owned are true on a currency, it will only show "held by: users" and not both (at least on v3+)

might be a better way to do this but I just took the easiest route of swapping the simple addition to array_merge(). I think the addition was freaking out because both arrays had the same keys or something, idk it was weird but it works now lol

also made them both uppercase because I think it looks way nicer/more in line with the other stuff you see on the entry. feel free to tell me to change it back though