### PR TITLE
fix(limits): adjust for $object->limits now returning empty collection

### DIFF
--- a/app/Services/LimitService.php
+++ b/app/Services/LimitService.php
@@ -60,9 +60,9 @@ class LimitService extends Service {
                         'limit_type'       => $data['limit_type'][$key],
                         'limit_id'         => $data['limit_id'][$key],
                         'quantity'         => $data['quantity'][$key],
-                        'debit'            => $data['debit'][$key] == 'no' ? 0 : 1,
-                        'is_unlocked'      => $data['is_unlocked'] == 'no' ? 0 : 1,
-                        'is_auto_unlocked' => $data['is_auto_unlocked'] == 'no' ? 0 : 1,
+                        'debit'            => $data['debit'][$key],
+                        'is_unlocked'      => $data['is_unlocked'],
+                        'is_auto_unlocked' => $data['is_auto_unlocked'],
                     ]);
 
                     if (!$limit->save()) {

--- a/resources/views/widgets/_add_limits.blade.php
+++ b/resources/views/widgets/_add_limits.blade.php
@@ -41,7 +41,7 @@
     {!! Form::hidden('object_id', $object->id) !!}
     <div class="limit">
         <div id="limits">
-            @if ($limits)
+            @if (count($limits))
                 <h5>Limits for {!! $limits->first()->object->displayName !!}</h5>
             @endif
             <div class="row">
@@ -54,7 +54,7 @@
                         <br />
                         The "Yes" option is good for one-time unlocks such as shops, locations, certain prompts, etc.
                     </p>
-                    {!! Form::select('is_unlocked', ['yes' => 'Yes', 'no' => 'No'], $limits?->first()->is_unlocked ? 'yes' : 'no', ['class' => 'form-control']) !!}
+                    {!! Form::select('is_unlocked', [true => 'Yes', false => 'No'], (count($limits) ? $limits->first()->is_unlocked : false), ['class' => 'form-control']) !!}
                 </div>
                 @if (!$hideAutoUnlock)
                     <div class="col-md form-group border-left">
@@ -72,13 +72,13 @@
                             This option is not suitable for objects that should have limits as part of an action workflow, ex. prompt submissions.
                         </div>
                         </p>
-                        {!! Form::select('is_auto_unlocked', ['yes' => 'Yes', 'no' => 'No'], $limits?->first()->is_auto_unlocked ? 'yes' : 'no', ['class' => 'form-control']) !!}
+                        {!! Form::select('is_auto_unlocked', [true => 'Yes', false => 'No'], (count($limits) ? $limits->first()->is_auto_unlocked : false), ['class' => 'form-control']) !!}
                     </div>
                 @else
                     {!! Form::hidden('is_auto_unlocked', 'yes') !!}
                 @endif
             </div>
-            @if ($limits)
+            @if (count($limits))
                 @foreach ($limits as $limit)
                     <div class="row">
                         <div class="col-md-3 form-group">
@@ -104,7 +104,7 @@
                             </div>
                             <div class="form-group debit {{ $limit->limit_type == 'currency' || $limit->limit_type == 'item' ? '' : 'hide' }}">
                                 {!! Form::label('Debit') !!}
-                                {!! Form::select('debit[]', ['yes' => 'Debit', 'no' => 'Don\'t Debit'], $limit->debit ? 'yes' : 'no', ['class' => 'form-control']) !!}
+                                {!! Form::select('debit[]', [true => 'Debit', false => 'Don\'t Debit'], $limit->debit, ['class' => 'form-control']) !!}
                             </div>
                         </div>
                         <div class="col-md-1 d-flex align-items-center">
@@ -115,10 +115,10 @@
             @endif
         </div>
         <div class="btn btn-secondary" id="add-limit">Add Limit</div>
-        @if ($limits)
+        @if (count($limits))
             <i class="fas fa-trash text-danger float-right mt-2 mx-2 fa-2x" data-toggle="tooltip" title="To delete limits, simply remove all existing limits and click 'Edit Limits'"></i>
         @endif
-        {!! Form::submit(($limits ? 'Edit' : 'Create') . ' Limits', ['class' => 'btn btn-primary float-right']) !!}
+        {!! Form::submit((count($limits) ? 'Edit' : 'Create') . ' Limits', ['class' => 'btn btn-primary float-right']) !!}
     </div>
     {!! Form::close() !!}
 </div>
@@ -138,7 +138,7 @@
             </div>
             <div class="form-group hide debit">
                 {!! Form::label('Debit') !!}
-                {!! Form::select('debit[]', ['yes' => 'Debit', 'no' => 'Don\'t Debit'], 'no', ['class' => 'form-control']) !!}
+                {!! Form::select('debit[]', [true => 'Debit', false => 'Don\'t Debit'], false, ['class' => 'form-control']) !!}
             </div>
         </div>
         <div class="col-md-1 d-flex align-items-center">

--- a/resources/views/widgets/_add_limits.blade.php
+++ b/resources/views/widgets/_add_limits.blade.php
@@ -54,7 +54,7 @@
                         <br />
                         The "Yes" option is good for one-time unlocks such as shops, locations, certain prompts, etc.
                     </p>
-                    {!! Form::select('is_unlocked', [true => 'Yes', false => 'No'], (count($limits) ? $limits->first()->is_unlocked : false), ['class' => 'form-control']) !!}
+                    {!! Form::select('is_unlocked', [true => 'Yes', false => 'No'], count($limits) ? $limits->first()->is_unlocked : false, ['class' => 'form-control']) !!}
                 </div>
                 @if (!$hideAutoUnlock)
                     <div class="col-md form-group border-left">
@@ -72,7 +72,7 @@
                             This option is not suitable for objects that should have limits as part of an action workflow, ex. prompt submissions.
                         </div>
                         </p>
-                        {!! Form::select('is_auto_unlocked', [true => 'Yes', false => 'No'], (count($limits) ? $limits->first()->is_auto_unlocked : false), ['class' => 'form-control']) !!}
+                        {!! Form::select('is_auto_unlocked', [true => 'Yes', false => 'No'], count($limits) ? $limits->first()->is_auto_unlocked : false, ['class' => 'form-control']) !!}
                     </div>
                 @else
                     {!! Form::hidden('is_auto_unlocked', 'yes') !!}


### PR DESCRIPTION
Resolves https://github.com/lk-arpg/lorekeeper/issues/1527 
(...kinda, we don't actually use `if($object->limits)` in core as far as I can tell. But this fixes any other areas that expect a null value instead of an empty array.)

It's a bit hard to track down in the [Laravel API docs](https://api.laravel.com/docs/10.x/Illuminate/Database/Eloquent/Relations/MorphMany.html), but the MorphMany relationship resolves to an empty collection instead of null when no elements are found. I didn't catch it, I think, because php considers an empty array to be falsey.

It's kind of just the nature of the beast from what I understand, so I've adjusted the logic here to accommodate. I figured a switch from `if($limits)` to `if(count($limits))` was sufficient.

Also updated some of the true/false logic while I was in there, because keeping it as 'yes' and 'no' vs true and false was getting really messy when I had to accommodate for `count($limits)`.

I don't thiiiiink anything in the Rewardable logic needs to change for the "empty array instead of null" change, but if so, I'll just put that in a different PR. At some point I might do a refactor to make the logic for limits and rewards behave more similarly.