### PR TITLE
fix: add selectRange to form adapter

### DIFF
--- a/app/Helpers/FormAdapter.php
+++ b/app/Helpers/FormAdapter.php
@@ -195,6 +195,13 @@ class FormAdapter {
         return $this->mergeOptions($element, $options);
     }
 
+    public function selectRange($name, $min = null, $max = null, $value = null, $options = []) {
+        $range = array_combine($range = range($min, $max), $range);
+        $element = html()->select($name, $range, $value);
+
+        return $this->mergeOptions($element, $options);
+    }
+
     private function mergeOptions($element, $options = []) {
         $newElement = $element;
 


### PR DESCRIPTION
Found a field type that wasn't covered by the adapter! Oops.

For reference, this is pretty much verbatim the behavior from `laravelcollective/html` (see https://github.com/LaravelCollective/html/blob/6.x/src/FormBuilder.php#L683).