### PR TITLE
chore(deps): update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,24 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "unstable"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "composer"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "unstable"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "unstable"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "weekly"


### PR DESCRIPTION
- update for develop branch rename
- add github-actions handling
- specify default cooldown days

Unsure why it hasn't been creating PRs for composer deps, but it probably doesn't help that the branch name is now out-of-date. Begrudgingly this will probably need to be a hotfix on account of the that that I presume it looks at the config file in the default branch like other similar tools.