### PR TITLE
feat(items): auto select stack in modal

### DIFF
--- a/app/Http/Controllers/Users/AccountController.php
+++ b/app/Http/Controllers/Users/AccountController.php
@@ -320,6 +320,25 @@ class AccountController extends Controller {
     }
 
     /**
+     * Changes user inventory stack auto-select setting.
+     *
+     * @param App\Services\UserService $service
+     *
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function postStackAutoSelect(Request $request, UserService $service) {
+        if ($service->updateStackAutoSelectSetting($request->input('stack_auto_selected'), Auth::user())) {
+            flash('Setting updated successfully.')->success();
+        } else {
+            foreach ($service->errors()->getMessages()['error'] as $error) {
+                flash($error)->error();
+            }
+        }
+
+        return redirect()->back();
+    }
+
+    /**
      * Shows the notifications page.
      *
      * @return \Illuminate\Contracts\Support\Renderable

--- a/app/Models/User/UserSettings.php
+++ b/app/Models/User/UserSettings.php
@@ -13,6 +13,7 @@ class UserSettings extends Model {
     protected $fillable = [
         'is_fto', 'submission_count', 'banned_at', 'ban_reason', 'birthday_setting',
         'deactivate_reason', 'deactivated_at', 'content_warning_visibility', 'allow_profile_comments',
+        'stack_auto_selected',
     ];
 
     /**

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -327,6 +327,29 @@ class UserService extends Service {
     }
 
     /**
+     * Updates user's inventory stack auto-select setting.
+     *
+     * @param mixed $data
+     * @param mixed $user
+     *
+     * @return bool
+     */
+    public function updateStackAutoSelectSetting($data, $user) {
+        DB::beginTransaction();
+
+        try {
+            $user->settings->stack_auto_selected = $data ?? 0;
+            $user->settings->save();
+
+            return $this->commitReturn(true);
+        } catch (\Exception $e) {
+            $this->setError('error', $e->getMessage());
+        }
+
+        return $this->rollbackReturn(false);
+    }
+
+    /**
      * Updates the user's avatar.
      *
      * @param User  $user

--- a/database/migrations/2026_08_27_143512_add_stack_auto_selected_to_user_settings.php
+++ b/database/migrations/2026_08_27_143512_add_stack_auto_selected_to_user_settings.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->boolean('stack_auto_selected')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::table('user_settings', function (Blueprint $table) {
+            $table->dropColumn('stack_auto_selected');
+        });
+    }
+};

--- a/database/migrations/2026_08_27_143512_add_stack_auto_selected_to_user_settings.php
+++ b/database/migrations/2026_08_27_143512_add_stack_auto_selected_to_user_settings.php
@@ -10,7 +10,7 @@ return new class extends Migration {
      */
     public function up(): void {
         Schema::table('user_settings', function (Blueprint $table) {
-            $table->boolean('stack_auto_selected')->default(0);
+            $table->boolean('stack_auto_selected')->default(1);
         });
     }
 

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -132,10 +132,15 @@
         <div class="form-group row">
             <label class="col-md-2 col-form-label">Setting</label>
             <div class="col-md-10">
-                {!! Form::select('stack_auto_selected', [
-                    '0' => '0: Disabled. You must select a stack yourself.', 
-                    '1' => '1: Enabled. The first stack is used automatically.'
-                ], Auth::user()->settings->stack_auto_selected, ['class' => 'form-control']) !!}
+                {!! Form::select(
+                    'stack_auto_selected',
+                    [
+                        '0' => '0: Disabled. You must select a stack yourself.',
+                        '1' => '1: Enabled. The first stack is used automatically.',
+                    ],
+                    Auth::user()->settings->stack_auto_selected,
+                    ['class' => 'form-control'],
+                ) !!}
             </div>
         </div>
         <div class="text-right">

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -124,6 +124,27 @@
     </div>
 
     <div class="card p-3 mb-2">
+        <h3>Auto-Select First Stack</h3>
+        {!! Form::open(['url' => 'account/stack-auto-select']) !!}
+        <p>
+            If enabled, using an item without explicitly selecting a stack will automatically select and use the first stack you own instead of doing nothing.
+        </p>
+        <div class="form-group row">
+            <label class="col-md-2 col-form-label">Setting</label>
+            <div class="col-md-10">
+                {!! Form::select('stack_auto_selected', [
+                    '0' => '0: Disabled. You must select a stack yourself.', 
+                    '1' => '1: Enabled. The first stack is used automatically.'
+                ], Auth::user()->settings->stack_auto_selected, ['class' => 'form-control']) !!}
+            </div>
+        </div>
+        <div class="text-right">
+            {!! Form::submit('Edit', ['class' => 'btn btn-primary']) !!}
+        </div>
+        {!! Form::close() !!}
+    </div>
+
+    <div class="card p-3 mb-2">
         <h3>Character Warning Visibility</h3>
         <p>This setting will change how characters with content warnings are displayed to you.</p>
         {!! Form::open(['url' => 'account/warning']) !!}

--- a/resources/views/character/_inventory_stack.blade.php
+++ b/resources/views/character/_inventory_stack.blade.php
@@ -145,9 +145,10 @@
         var $rowId = "#itemRow" + $checkbox.value
         $($rowId).find('.quantity-select').prop('name', $checkbox.checked ? 'quantities[]' : '')
     }
-    
+
     @if (!$readOnly && $user && $user->settings->stack_auto_selected)
         var $autoSelectNotice = $('#autoSelectNotice');
+
         function updateAutoSelectNotice() {
             $autoSelectNotice.toggle($('.item-check:checked').length == 0);
         }

--- a/resources/views/character/_inventory_stack.blade.php
+++ b/resources/views/character/_inventory_stack.blade.php
@@ -60,6 +60,11 @@
     </div>
 
     @if ($user && !$readOnly && ($owner_id == $user->id || $has_power == true))
+        @if ($user->settings->stack_auto_selected)
+            <div id="autoSelectNotice" class="alert alert-info py-2 mb-2 text-center font-weight-bold">
+                <i class="fas fa-info-circle" aria-hidden="true"></i> No stack selected. The first stack will be used automatically.
+            </div>
+        @endif
         <div class="card mt-3">
             <ul class="list-group list-group-flush">
                 @if ($item->category->can_name)
@@ -140,4 +145,25 @@
         var $rowId = "#itemRow" + $checkbox.value
         $($rowId).find('.quantity-select').prop('name', $checkbox.checked ? 'quantities[]' : '')
     }
+    
+    @if (!$readOnly && $user && $user->settings->stack_auto_selected)
+        var $autoSelectNotice = $('#autoSelectNotice');
+        function updateAutoSelectNotice() {
+            $autoSelectNotice.toggle($('.item-check:checked').length == 0);
+        }
+
+        updateAutoSelectNotice();
+
+        $('.item-check').on('change', updateAutoSelectNotice);
+        $('#toggle-checks').on('click', updateAutoSelectNotice);
+
+        $('form[action="{{ url('character/' . $character->slug . '/inventory/edit') }}"]').on('submit', function() {
+            var $checks = $(this).find('.item-check');
+            if ($checks.length && !$checks.filter(':checked').length) {
+                var $first = $checks.first();
+                $first.prop('checked', true);
+                updateQuantities($first[0]);
+            }
+        });
+    @endif
 </script>

--- a/resources/views/home/_inventory_stack.blade.php
+++ b/resources/views/home/_inventory_stack.blade.php
@@ -87,6 +87,11 @@
     </div>
 
     @if ($user && !$readOnly && ($stack->first()->user_id == $user->id || $user->hasPower('edit_inventories')))
+        @if ($user->settings->stack_auto_selected)
+            <div id="autoSelectNotice" class="alert alert-info py-2 mb-2 text-center font-weight-bold">
+                <i class="fas fa-info-circle" aria-hidden="true"></i> No stack selected. The first stack will be used automatically.
+            </div>
+        @endif
         <div class="card mt-3">
             <ul class="list-group list-group-flush">
                 @if (count($item->tags))
@@ -189,4 +194,25 @@
         var $rowId = "#itemRow" + $checkbox.value
         $($rowId).find('.quantity-select').prop('name', $checkbox.checked ? 'quantities[]' : '')
     }
+
+    @if (!$readOnly && $user && $user->settings->stack_auto_selected)
+        var $autoSelectNotice = $('#autoSelectNotice');
+        function updateAutoSelectNotice() {
+            $autoSelectNotice.toggle($('.item-check:checked').length == 0);
+        }
+
+        updateAutoSelectNotice();
+
+        $('.item-check').on('change', updateAutoSelectNotice);
+        $('#toggle-checks').on('click', updateAutoSelectNotice);
+
+        $('form[action="{{ url('inventory/edit') }}"]').on('submit', function() {
+            var $checks = $(this).find('.item-check');
+            if ($checks.length && !$checks.filter(':checked').length) {
+                var $first = $checks.first();
+                $first.prop('checked', true);
+                updateQuantities($first[0]);
+            }
+        });
+    @endif
 </script>

--- a/resources/views/home/_inventory_stack.blade.php
+++ b/resources/views/home/_inventory_stack.blade.php
@@ -197,6 +197,7 @@
 
     @if (!$readOnly && $user && $user->settings->stack_auto_selected)
         var $autoSelectNotice = $('#autoSelectNotice');
+
         function updateAutoSelectNotice() {
             $autoSelectNotice.toggle($('.item-check:checked').length == 0);
         }

--- a/routes/lorekeeper/members.php
+++ b/routes/lorekeeper/members.php
@@ -39,6 +39,7 @@ Route::group(['prefix' => 'account', 'namespace' => 'Users'], function () {
     Route::post('dob', 'AccountController@postBirthday');
     Route::post('warning', 'AccountController@postWarningVisibility');
     Route::post('comments', 'AccountController@postProfileComments');
+    Route::post('stack-auto-select', 'AccountController@postStackAutoSelect');
 
     Route::get('two-factor/confirm', 'AccountController@getConfirmTwoFactor');
     Route::post('two-factor/enable', 'AccountController@postEnableTwoFactor');


### PR DESCRIPTION
So we can collectively stop having users confused on why nothing is happening because they don't realize an item stack needs to be selected, hahaha.

As per moif's recommendation, this is an *opt-in* user setting - so users are aware they have chosen to enable this for their own/their characters' inventories and won't accidentally lose something. `php artisan migrate` as usual.

When opted in, there is a banner - when no stack is selected - saying that because nothing is selected, the first stack will automatically be selected and used. The banner goes away if a stack is intentionally selected. It still hits whatever checks in the back for the action selected (i.e. if the first stack is accountbound and the user tries to transfer, it'll still throw an exception).