### PR TITLE
feat(items): display item tag descriptions and tooltips

### DIFF
--- a/app/Models/Item/Item.php
+++ b/app/Models/Item/Item.php
@@ -194,7 +194,33 @@ class Item extends Model {
      * @return string
      */
     public function getDisplayNameAttribute() {
-        return '<a href="'.$this->idUrl.'" class="display-item">'.$this->name.'</a>';
+        return '<a href="'.$this->idUrl.'" class="display-item">'.$this->name.'</a>'.$this->tagTooltip;
+    }
+
+    /**
+     * Builds a help-icon tooltip listing the item's active tags and their descriptions.
+     *
+     * @return string
+     */
+    public function getTagTooltipAttribute() {
+        if (!config('lorekeeper.extensions.item_tag_tooltips')) {
+            return null;
+        }
+
+        $lines = [];
+        foreach ($this->tags->where('is_active', 1) as $t) {
+            $description = config('lorekeeper.item_tags.'.$t->tag.'.description');
+            if (!$description) {
+                continue;
+            }
+            $lines[] = $t->displayTagTooltip.' '.$description;
+        }
+
+        if (!$lines) {
+            return null;
+        }
+
+        return add_help(implode('<br>', $lines));
     }
 
     /**

--- a/app/Models/Item/Item.php
+++ b/app/Models/Item/Item.php
@@ -216,7 +216,7 @@ class Item extends Model {
             $lines[] = $t->displayTagTooltip.' '.$description;
         }
 
-        if (!$lines) {
+        if (empty($lines)) {
             return null;
         }
 

--- a/app/Models/Item/ItemTag.php
+++ b/app/Models/Item/ItemTag.php
@@ -87,7 +87,26 @@ class ItemTag extends Model {
     public function getDisplayTagAttribute() {
         $tag = config('lorekeeper.item_tags.'.$this->tag);
         if ($tag) {
-            return '<span class="badge" style="color: '.$tag['text_color'].';background-color: '.$tag['background_color'].';">'.$tag['name'].'</span>';
+            $tooltip = '';
+            if (config('lorekeeper.extensions.item_tag_tooltips') && isset($tag['description']) && $tag['description']) {
+                $tooltip = ' data-toggle="tooltip" title="'.$tag['description'].'"';
+            }
+
+            return '<span class="badge"'.$tooltip.' style="color: '.$tag['text_color'].';background-color: '.$tag['background_color'].';">'.$tag['name'].'</span>';
+        }
+
+        return null;
+    }
+
+    /**
+     * Displays the tag badge using single quotes, safe for embedding in a tooltip's title attribute.
+     *
+     * @return string
+     */
+    public function getDisplayTagTooltipAttribute() {
+        $tag = config('lorekeeper.item_tags.'.$this->tag);
+        if ($tag) {
+            return '<span class=\'badge mr-1\' style=\'color: '.$tag['text_color'].';background-color: '.$tag['background_color'].';\'>'.$tag['name'].'</span>';
         }
 
         return null;

--- a/config/lorekeeper/extensions.php
+++ b/config/lorekeeper/extensions.php
@@ -141,6 +141,9 @@ return [
     // Unmerge Item Page and Item Entry - Speedy
     'unmerge_item_page_and_entry' => 0, // If enabled, uses the html on world/item_page.blade.php instead of the include that links to world/_item_entry.blade.php
 
+    // Item Tag Tooltips - Min
+    'item_tag_tooltips' => 0, // If enabled, item tag badges & items show a tooltip with the tag's description. Tags without a description will not show a tooltip.
+
     // Unmerge Trait Page and Trait Entry - Speedy
     'unmerge_feature_page_and_entry' => 0, // If enabled, uses the html on world/feature_page.blade.php instead of the include that links to world/_feature_entry.blade.php
 

--- a/config/lorekeeper/item_tags.php
+++ b/config/lorekeeper/item_tags.php
@@ -17,17 +17,20 @@ return [
         'name'             => 'Box',
         'text_color'       => '#ffffff',
         'background_color' => '#f6993f',
+        'description'      => 'This item can be opened for a preset reward.',
     ],
 
     'slot' => [
         'name'             => 'Slot',
         'text_color'       => '#ffffff',
         'background_color' => '#1fd1a7',
+        'description'      => 'This item can be used to create an MYO slot.',
     ],
 
     'coupon' => [
         'name'             => 'Coupon',
         'text_color'       => '#ffffff',
         'background_color' => '#ff5ca8',
+        'description'      => 'This item can be redeemed at an eligible shop for a discount.',
     ],
 ];


### PR DESCRIPTION
I said I would PR this like forever ago...hi. |D
Toggleable in extensions config. Gives both item tag badges as well as item names themselves a tooltip, if they have an item tag, on what exactly the item tag is for. If an item tag lacks a description in the config, it simply won't render a tooltip.

...I was too lazy to take actual screenshots so I will [gesture at CC's item index](https://www.cupidcats.online/world/items) as example. 👍 